### PR TITLE
ApiException Error Handling

### DIFF
--- a/README.md
+++ b/README.md
@@ -51,6 +51,9 @@ This library is the abstraction of Xendit API for access from applications writt
     - [Get Fixed Virtual Account](#get-fixed-virtual-account)
     - [Update Fixed Virtual Account](#update-fixed-virtual-account)
     - [Get Fixed Virtual Account Payment](#get-fixed-virtual-account-payment)
+- [Exceptions](#exceptions)
+  - [InvalidArgumentException](#invalidargumentexception)
+  - [ApiException](#apiexception)
 - [Contributing](#contributing)
   - [Test](#tests)
     - [Running test suite](#running-test-suite)
@@ -820,6 +823,50 @@ Usage example:
 $paymentID = 'payment-ID';
 $getFVAPayment = \Xendit\VirtualAccounts::getFVAPayment($paymentID);
 var_dump($getFVAPayment);
+```
+
+## Exceptions
+
+### InvalidArgumentException
+
+`InvalidArgumentException` will be thrown if the argument provided by user is not sufficient to create the request.
+
+For example, there are required arguments such as `external_id`, `payer_email`, `description`, and `amount` to create an invoice. If user lacks one or more arguments when attempting to create one, `InvalidArgumentException` will be thrown.
+
+`InvalidArgumentException` is derived from PHP's `InvalidArgumentException`. For more information about this Exception methods and properties, please check [PHP Documentation](https://www.php.net/manual/en/class.invalidargumentexception.php).
+
+### ApiException
+
+`ApiException` wraps up Xendit API error. This exception will be thrown if there are errors from Xendit API side, e.g. get fixed virtual account with invalid `id`. 
+
+To get exception message:
+
+```php
+try {
+    $getInvoice = \Xendit\Invoice::retrieve('123');
+} catch (\Xendit\Exceptions\ApiException $e) {
+    var_dump($e->getMessage());
+}
+```
+
+To get exception HTTP error code:
+
+```php
+try {
+    $getInvoice = \Xendit\Invoice::retrieve('123');
+} catch (\Xendit\Exceptions\ApiException $e) {
+    var_dump($e->getCode());
+}
+```
+
+To get exception Xendit API error code:
+
+```php
+try {
+    $getInvoice = \Xendit\Invoice::retrieve('123');
+} catch (\Xendit\Exceptions\ApiException $e) {
+    var_dump($e->getErrorCode());
+}
 ```
 
 ## Contributing

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "xendit/xendit-php",
     "description": "PHP clients for Xendit API",
-    "version": "2.0.2",
+    "version": "2.0.3",
     "keywords": ["xendit"],
     "homepage": "https://github.com/xendit/xendit-php",
     "type": "library",

--- a/examples/EWalletsExample.php
+++ b/examples/EWalletsExample.php
@@ -63,7 +63,7 @@ $linkajaParams = [
 try {
     $createOvo = \Xendit\EWallets::create($ovoParams);
     var_dump($createOvo);
-} catch (\Xendit\Exceptions\ApiExceptions $exception) {
+} catch (\Xendit\Exceptions\ApiException $exception) {
     var_dump($exception);
 }
 

--- a/src/ApiOperations/Request.php
+++ b/src/ApiOperations/Request.php
@@ -56,7 +56,7 @@ trait Request
      * @param $params array parameters
      *
      * @return array
-     * @throws \Xendit\Exceptions\ApiExceptions
+     * @throws \Xendit\Exceptions\ApiException
      */
     protected static function _request($method,
         $url,

--- a/src/ApiRequestor.php
+++ b/src/ApiRequestor.php
@@ -35,7 +35,7 @@ class ApiRequestor
      * @param array  $headers user's additional headers
      *
      * @return array
-     * @throws Exceptions\ApiExceptions
+     * @throws Exceptions\ApiException
      */
     public function request($method, $url, $params = [], $headers = [])
     {
@@ -74,7 +74,7 @@ class ApiRequestor
      * @param array  $headers request' headers
      *
      * @return array
-     * @throws Exceptions\ApiExceptions
+     * @throws Exceptions\ApiException
      */
     private function _requestRaw($method, $url, $params, $headers)
     {

--- a/src/Balance.php
+++ b/src/Balance.php
@@ -61,7 +61,7 @@ class Balance
      * @return array[
      *  'balance' => int
      * ]
-     * @throws Exceptions\ApiExceptions
+     * @throws Exceptions\ApiException
      */
     public static function getBalance($account_type = null)
     {

--- a/src/Cards.php
+++ b/src/Cards.php
@@ -62,7 +62,7 @@ class Cards
      *  'descriptor' => string,
      *  'id' => string
      * ]
-     * @throws Exceptions\ApiExceptions
+     * @throws Exceptions\ApiException
      */
     public static function capture($id, $params = [])
     {
@@ -99,7 +99,7 @@ class Cards
      *  'status' => string,
      *  'id' => string
      * ]
-     * @throws Exceptions\ApiExceptions
+     * @throws Exceptions\ApiException
      */
     public static function reverseAuthorization($id, $params = [])
     {
@@ -129,7 +129,7 @@ class Cards
      *  'fee_refund_amount' => int,
      *  'id' => string
      * ]
-     * @throws Exceptions\ApiExceptions
+     * @throws Exceptions\ApiException
      */
     public static function createRefund($id, $params = [])
     {

--- a/src/Disbursements.php
+++ b/src/Disbursements.php
@@ -66,7 +66,7 @@ class Disbursements
      * 'status'=> 'NEEDS_APPROVAL',
      * 'id'=> string
      * ]
-     * @throws Exceptions\ApiExceptions
+     * @throws Exceptions\ApiException
      */
     public static function createBatch($params = [])
     {
@@ -108,7 +108,7 @@ class Disbursements
      * 'email_bcc'=> ['test+bcc@xendit.co']
      * ]
      * ]
-     * @throws Exceptions\ApiExceptions
+     * @throws Exceptions\ApiException
      */
     public static function retrieveExternal($external_id)
     {
@@ -136,7 +136,7 @@ class Disbursements
      * 'can_disburse'=> true,
      * 'can_name_validate'=> true
      * ]]
-     * @throws Exceptions\ApiExceptions
+     * @throws Exceptions\ApiException
      */
     public static function getAvailableBanks()
     {

--- a/src/EWallets.php
+++ b/src/EWallets.php
@@ -45,7 +45,7 @@ class EWallets
      *
      * @return array please check for responses for each e-wallet type
      * https://xendit.github.io/apireference/?bash#create-payment
-     * @throws Exceptions\ApiExceptions
+     * @throws Exceptions\ApiException
      */
     public static function create($params = [])
     {
@@ -81,7 +81,7 @@ class EWallets
      *
      * @return array please check for responses for each e-wallet type
      * https://xendit.github.io/apireference/?bash#get-payment-status
-     * @throws Exceptions\ApiExceptions
+     * @throws Exceptions\ApiException
      */
     public static function getPaymentStatus($external_id, $ewallet_type)
     {

--- a/src/Exceptions/ApiException.php
+++ b/src/Exceptions/ApiException.php
@@ -22,6 +22,21 @@ namespace Xendit\Exceptions;
  * @license  https://opensource.org/licenses/MIT MIT License
  * @link     https://api.xendit.co
  */
-class ApiExceptions extends \Exception implements ExceptionInterface
+class ApiException extends \Exception implements ExceptionInterface
 {
+    protected $errorCode;
+
+    public function getErrorCode() 
+    {
+        return $this->errorCode;
+    }
+
+    public function __construct($message, $code, $errorCode)
+    {
+        if (!$message) {
+            throw new $this('Unknown '. get_class($this));
+        }
+        parent::__construct($message, $code);
+        $this->errorCode = $errorCode;
+    }
 }

--- a/src/Exceptions/ExceptionInterface.php
+++ b/src/Exceptions/ExceptionInterface.php
@@ -24,4 +24,5 @@ namespace Xendit\Exceptions;
  */
 interface ExceptionInterface extends \Throwable
 {
+    public function getErrorCode();
 }

--- a/src/Exceptions/InvalidArgumentException.php
+++ b/src/Exceptions/InvalidArgumentException.php
@@ -24,6 +24,5 @@ namespace Xendit\Exceptions;
  */
 class InvalidArgumentException
     extends \InvalidArgumentException
-    implements ExceptionInterface
 {
 }

--- a/src/HttpClient/ClientInterface.php
+++ b/src/HttpClient/ClientInterface.php
@@ -13,7 +13,7 @@
 
 namespace Xendit\HttpClient;
 
-use Xendit\Exceptions\ApiExceptions;
+use Xendit\Exceptions\ApiException;
 
 /**
  * Interface ClientInterface
@@ -35,7 +35,7 @@ interface ClientInterface
      * @param array  $params         parameters
      *
      * @return array
-     * @throws ApiExceptions
+     * @throws ApiException
      */
     public function sendRequest($method,
         string $url,

--- a/src/HttpClient/GuzzleClient.php
+++ b/src/HttpClient/GuzzleClient.php
@@ -17,7 +17,7 @@ use GuzzleHttp\Client as Guzzle;
 use GuzzleHttp\Exception\ClientException;
 use GuzzleHttp\Exception\ServerException;
 use GuzzleHttp\RequestOptions;
-use Xendit\Exceptions\ApiExceptions;
+use Xendit\Exceptions\ApiException;
 use Xendit\Xendit;
 
 /**
@@ -77,7 +77,7 @@ class GuzzleClient implements ClientInterface
      * @param array  $params         parameters
      *
      * @return array
-     * @throws ApiExceptions
+     * @throws ApiException
      */
     public function sendRequest($method, string $url, array $defaultHeaders, $params)
     {
@@ -101,7 +101,7 @@ class GuzzleClient implements ClientInterface
      * @param string $url  request url
      *
      * @return array
-     * @throws ApiExceptions
+     * @throws ApiException
      */
     private function _executeRequest(array $opts, string $url)
     {
@@ -153,17 +153,16 @@ class GuzzleClient implements ClientInterface
      * @param array $response response from GuzzleClient
      *
      * @return void
-     * @throws ApiExceptions
+     * @throws ApiException
      */
     private static function _handleAPIError($response)
     {
         $rbody = $response['body'];
-        $rcode = strval($response['code']);
+        
+        $rhttp = strval($response['code']);
+        $message = $rbody['message'];
+        $rcode = $rbody['error_code'];
 
-        $message = 'API Exception: ' . $rbody['message'] . ' Error code: '
-                   . $rcode . ' ' . $rbody['error_code'] . '. More information: '
-                   . 'https://xendit.github.io/apireference/?bash#http-status-code';
-
-        throw new ApiExceptions($message);
+        throw new ApiException($message, $rhttp, $rcode);
     }
 }

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -72,7 +72,7 @@ class Invoice
      * 'created'=> string,
      * 'updated'=> string
      * ]
-     * @throws Exceptions\ApiExceptions
+     * @throws Exceptions\ApiException
      */
     public static function expireInvoice($id)
     {

--- a/src/Payouts.php
+++ b/src/Payouts.php
@@ -64,7 +64,7 @@ class Payouts
      * 'expiration_timestamp'=> string,
      * 'created'=> string'
      * ]
-     * @throws Exceptions\ApiExceptions
+     * @throws Exceptions\ApiException
      */
     public static function void($id)
     {

--- a/src/Recurring.php
+++ b/src/Recurring.php
@@ -89,7 +89,7 @@ class Recurring
      * 'updated'=> string,
      * 'start_date'=> string
      * ]
-     * @throws Exceptions\ApiExceptions
+     * @throws Exceptions\ApiException
      */
     public static function stop($id)
     {
@@ -121,7 +121,7 @@ class Recurring
      * 'updated'=> string,
      * 'start_date'=> string
      * ]
-     * @throws Exceptions\ApiExceptions
+     * @throws Exceptions\ApiException
      */
     public static function pause($id)
     {
@@ -153,7 +153,7 @@ class Recurring
      * 'updated'=> string,
      * 'start_date'=> string
      * ]
-     * @throws Exceptions\ApiExceptions
+     * @throws Exceptions\ApiException
      */
     public static function resume($id)
     {

--- a/src/VirtualAccounts.php
+++ b/src/VirtualAccounts.php
@@ -66,7 +66,7 @@ class VirtualAccounts
      * 'name' => string,
      * 'code' => string
      * ]
-     * @throws Exceptions\ApiExceptions
+     * @throws Exceptions\ApiException
      */
     public static function getVABanks()
     {
@@ -91,7 +91,7 @@ class VirtualAccounts
      * 'amount'=> int,
      * 'transaction_timestamp'=> string
      * ]
-     * @throws Exceptions\ApiExceptions
+     * @throws Exceptions\ApiException
      */
     public static function getFVAPayment($payment_id)
     {

--- a/src/Xendit.php
+++ b/src/Xendit.php
@@ -32,7 +32,7 @@ class Xendit
 
     public static $libVersion;
 
-    const VERSION = "2.0.0";
+    const VERSION = "2.0.3";
 
     /**
      * ApiBase getter

--- a/tests/Xendit/BalanceTest.php
+++ b/tests/Xendit/BalanceTest.php
@@ -35,7 +35,7 @@ class BalanceTest extends TestCase
      * Should pass
      *
      * @return void
-     * @throws Exceptions\ApiExceptions
+     * @throws Exceptions\ApiException
      */
     public function testIsGettable()
     {
@@ -59,7 +59,7 @@ class BalanceTest extends TestCase
      *
      * @return void
      * @throws Exceptions\InvalidArgumentException
-     * @throws Exceptions\ApiExceptions
+     * @throws Exceptions\ApiException
      */
     public function testIsGettableThrowInvalidArgumentException()
     {

--- a/tests/Xendit/CardsTest.php
+++ b/tests/Xendit/CardsTest.php
@@ -110,7 +110,7 @@ class CardsTest extends TestCase
      * Should pass
      *
      * @return void
-     * @throws Exceptions\ApiExceptions
+     * @throws Exceptions\ApiException
      */
     public function testIsCaptureable()
     {
@@ -136,7 +136,7 @@ class CardsTest extends TestCase
      * Should pass
      *
      * @return void
-     * @throws Exceptions\ApiExceptions
+     * @throws Exceptions\ApiException
      */
     public function testIsRefundable()
     {
@@ -164,7 +164,7 @@ class CardsTest extends TestCase
      * Should pass
      *
      * @return void
-     * @throws Exceptions\ApiExceptions
+     * @throws Exceptions\ApiException
      */
     public function testIsReversable()
     {
@@ -209,7 +209,7 @@ class CardsTest extends TestCase
      */
     public function testIsGettableThrowException()
     {
-        $this->expectException(\Xendit\Exceptions\ApiExceptions::class);
+        $this->expectException(\Xendit\Exceptions\ApiException::class);
 
         Cards::retrieve(self::CHARGE_ID);
     }
@@ -219,7 +219,7 @@ class CardsTest extends TestCase
      * Should throw ApiException
      *
      * @return void
-     * @throws Exceptions\ApiExceptions
+     * @throws Exceptions\ApiException
      */
     public function testIsCaptureableThrowException()
     {
@@ -227,7 +227,7 @@ class CardsTest extends TestCase
             'amount'=> 100000
         ];
 
-        $this->expectException(\Xendit\Exceptions\ApiExceptions::class);
+        $this->expectException(\Xendit\Exceptions\ApiException::class);
         Cards::capture(self::CHARGE_ID, $params);
     }
 
@@ -236,7 +236,7 @@ class CardsTest extends TestCase
      * Should throw ApiException
      *
      * @return void
-     * @throws Exceptions\ApiExceptions
+     * @throws Exceptions\ApiException
      */
     public function testIsRefundableThrowException()
     {
@@ -245,7 +245,7 @@ class CardsTest extends TestCase
             'external_id' => 'card_' . time(),
         ];
 
-        $this->expectException(\Xendit\Exceptions\ApiExceptions::class);
+        $this->expectException(\Xendit\Exceptions\ApiException::class);
         Cards::createRefund(self::CHARGE_ID, $params);
     }
 
@@ -254,7 +254,7 @@ class CardsTest extends TestCase
      * Should throw ApiException
      *
      * @return void
-     * @throws Exceptions\ApiExceptions
+     * @throws Exceptions\ApiException
      */
     public function testIsReversableThrowException()
     {
@@ -262,7 +262,7 @@ class CardsTest extends TestCase
             'external_id' => 'card_' . time()
         ];
 
-        $this->expectException(\Xendit\Exceptions\ApiExceptions::class);
+        $this->expectException(\Xendit\Exceptions\ApiException::class);
         Cards::reverseAuthorization(self::CHARGE_ID, $params);
     }
 }

--- a/tests/Xendit/DisbursementsTest.php
+++ b/tests/Xendit/DisbursementsTest.php
@@ -69,7 +69,7 @@ class DisbursementsTest extends TestCase
      * Should pass
      *
      * @return void
-     * @throws \Xendit\Exceptions\ApiExceptions
+     * @throws \Xendit\Exceptions\ApiException
      */
     public function testIsBatchCreatable()
     {
@@ -116,7 +116,7 @@ class DisbursementsTest extends TestCase
      * Should pass
      *
      * @return void
-     * @throws \Xendit\Exceptions\ApiExceptions
+     * @throws \Xendit\Exceptions\ApiException
      */
     public function testBanksIsGettable()
     {
@@ -174,7 +174,7 @@ class DisbursementsTest extends TestCase
      * Should pass
      *
      * @return void
-     * @throws \Xendit\Exceptions\ApiExceptions
+     * @throws \Xendit\Exceptions\ApiException
      */
     public function testIsGettableByExternalID()
     {
@@ -213,7 +213,7 @@ class DisbursementsTest extends TestCase
      * Should throw InvalidArgumentException
      *
      * @return void
-     * @throws \Xendit\Exceptions\ApiExceptions
+     * @throws \Xendit\Exceptions\ApiException
      */
     public function testIsBatchCreatableThrowInvalidArgumentException()
     {
@@ -233,7 +233,7 @@ class DisbursementsTest extends TestCase
      */
     public function testIsGettableByIDThrowApiException()
     {
-        $this->expectException(\Xendit\Exceptions\ApiExceptions::class);
+        $this->expectException(\Xendit\Exceptions\ApiException::class);
 
         Disbursements::retrieve(self::TEST_ID);
     }
@@ -243,11 +243,11 @@ class DisbursementsTest extends TestCase
      * Should throw ApiException
      *
      * @return void
-     * @throws \Xendit\Exceptions\ApiExceptions
+     * @throws \Xendit\Exceptions\ApiException
      */
     public function testIsGettableByExtIDThrowApiException()
     {
-        $this->expectException(\Xendit\Exceptions\ApiExceptions::class);
+        $this->expectException(\Xendit\Exceptions\ApiException::class);
 
         Disbursements::retrieveExternal(self::TEST_ID);
     }

--- a/tests/Xendit/EWalletsTest.php
+++ b/tests/Xendit/EWalletsTest.php
@@ -35,7 +35,7 @@ class EWalletsTest extends TestCase
      * Should pass
      *
      * @return void
-     * @throws Exceptions\ApiExceptions
+     * @throws Exceptions\ApiException
      */
     public function testIsCreatable()
     {
@@ -85,7 +85,7 @@ class EWalletsTest extends TestCase
      * Should pass
      *
      * @return void
-     * @throws Exceptions\ApiExceptions
+     * @throws Exceptions\ApiException
      */
     public function testIsGettable()
     {
@@ -124,7 +124,7 @@ class EWalletsTest extends TestCase
      * Should throw InvalidArgumentException
      *
      * @return void
-     * @throws Exceptions\ApiExceptions
+     * @throws Exceptions\ApiException
      */
     public function testIsCreatableThrowInvalidArgumentException()
     {
@@ -141,11 +141,11 @@ class EWalletsTest extends TestCase
      * Should throw ApiException
      *
      * @return void
-     * @throws Exceptions\ApiExceptions
+     * @throws Exceptions\ApiException
      */
     public function testIsGettableThrowApiException()
     {
-        $this->expectException(\Xendit\Exceptions\ApiExceptions::class);
+        $this->expectException(\Xendit\Exceptions\ApiException::class);
 
         EWallets::getPaymentStatus(
             self::TEST_ID,

--- a/tests/Xendit/InvoiceTest.php
+++ b/tests/Xendit/InvoiceTest.php
@@ -109,7 +109,7 @@ class InvoiceTest extends TestCase
      * Should pass
      *
      * @return void
-     * @throws \Xendit\Exceptions\ApiExceptions
+     * @throws \Xendit\Exceptions\ApiException
      */
     public function testIsExpirable()
     {
@@ -155,7 +155,7 @@ class InvoiceTest extends TestCase
      */
     public function testIsGettableThrowApiException()
     {
-        $this->expectException(\Xendit\Exceptions\ApiExceptions::class);
+        $this->expectException(\Xendit\Exceptions\ApiException::class);
 
         Invoice::retrieve(self::TEST_RESOURCE_ID);
     }
@@ -165,11 +165,11 @@ class InvoiceTest extends TestCase
      * Should throw ApiException
      *
      * @return void
-     * @throws \Xendit\Exceptions\ApiExceptions
+     * @throws \Xendit\Exceptions\ApiException
      */
     public function testIsExpirableThrowApiException()
     {
-        $this->expectException(\Xendit\Exceptions\ApiExceptions::class);
+        $this->expectException(\Xendit\Exceptions\ApiException::class);
 
         Invoice::expireInvoice(self::TEST_RESOURCE_ID);
     }

--- a/tests/Xendit/PayoutsTest.php
+++ b/tests/Xendit/PayoutsTest.php
@@ -84,7 +84,7 @@ class PayoutsTest extends TestCase
      * Should pass
      *
      * @return void
-     * @throws \Xendit\Exceptions\ApiExceptions
+     * @throws \Xendit\Exceptions\ApiException
      */
     public function testIsVoidable()
     {
@@ -127,7 +127,7 @@ class PayoutsTest extends TestCase
      */
     public function testIsGettableThrowApiException()
     {
-        $this->expectException(\Xendit\Exceptions\ApiExceptions::class);
+        $this->expectException(\Xendit\Exceptions\ApiException::class);
 
         Payouts::retrieve(self::TEST_ID);
     }
@@ -137,11 +137,11 @@ class PayoutsTest extends TestCase
      * Should throw
      *
      * @return void
-     * @throws \Xendit\Exceptions\ApiExceptions
+     * @throws \Xendit\Exceptions\ApiException
      */
     public function testIsVoidableThrowApiException()
     {
-        $this->expectException(\Xendit\Exceptions\ApiExceptions::class);
+        $this->expectException(\Xendit\Exceptions\ApiException::class);
 
         Payouts::void(self::TEST_ID);
     }

--- a/tests/Xendit/RecurringTest.php
+++ b/tests/Xendit/RecurringTest.php
@@ -118,7 +118,7 @@ class RecurringTest extends TestCase
      * Should pass
      *
      * @return void
-     * @throws Exceptions\ApiExceptions
+     * @throws Exceptions\ApiException
      */
     public function testIsStoppable()
     {
@@ -143,7 +143,7 @@ class RecurringTest extends TestCase
      * Should pass
      *
      * @return void
-     * @throws Exceptions\ApiExceptions
+     * @throws Exceptions\ApiException
      */
     public function testIsPausable()
     {
@@ -168,7 +168,7 @@ class RecurringTest extends TestCase
      * Should pass
      *
      * @return void
-     * @throws Exceptions\ApiExceptions
+     * @throws Exceptions\ApiException
      */
     public function testIsResumable()
     {
@@ -214,7 +214,7 @@ class RecurringTest extends TestCase
      */
     public function testIsGettableThrowApiException()
     {
-        $this->expectException(\Xendit\Exceptions\ApiExceptions::class);
+        $this->expectException(\Xendit\Exceptions\ApiException::class);
 
         Recurring::retrieve(self::TEST_ID);
     }
@@ -231,7 +231,7 @@ class RecurringTest extends TestCase
             'amount' => 32000
         ];
 
-        $this->expectException(\Xendit\Exceptions\ApiExceptions::class);
+        $this->expectException(\Xendit\Exceptions\ApiException::class);
 
         Recurring::update(self::TEST_ID, $params);
     }
@@ -241,11 +241,11 @@ class RecurringTest extends TestCase
      * Should throw ApiException
      *
      * @return void
-     * @throws Exceptions\ApiExceptions
+     * @throws Exceptions\ApiException
      */
     public function testIsStoppableThrowException()
     {
-        $this->expectException(\Xendit\Exceptions\ApiExceptions::class);
+        $this->expectException(\Xendit\Exceptions\ApiException::class);
 
         Recurring::stop(self::TEST_ID);
     }
@@ -255,11 +255,11 @@ class RecurringTest extends TestCase
      * Should throw ApiException
      *
      * @return void
-     * @throws Exceptions\ApiExceptions
+     * @throws Exceptions\ApiException
      */
     public function testIsPausableThrowException()
     {
-        $this->expectException(\Xendit\Exceptions\ApiExceptions::class);
+        $this->expectException(\Xendit\Exceptions\ApiException::class);
 
         Recurring::pause(self::TEST_ID);
     }
@@ -269,11 +269,11 @@ class RecurringTest extends TestCase
      * Should throw ApiException
      *
      * @return void
-     * @throws Exceptions\ApiExceptions
+     * @throws Exceptions\ApiException
      */
     public function testIsResumableThrowException()
     {
-        $this->expectException(\Xendit\Exceptions\ApiExceptions::class);
+        $this->expectException(\Xendit\Exceptions\ApiException::class);
 
         $result = Recurring::resume(self::TEST_ID);
     }

--- a/tests/Xendit/RetailTest.php
+++ b/tests/Xendit/RetailTest.php
@@ -137,7 +137,7 @@ class RetailTest extends TestCase
      */
     public function testIsGettableThrowApiException()
     {
-        $this->expectException(\Xendit\Exceptions\ApiExceptions::class);
+        $this->expectException(\Xendit\Exceptions\ApiException::class);
 
         Retail::retrieve(self::TEST_ID);
     }
@@ -150,7 +150,7 @@ class RetailTest extends TestCase
      */
     public function testIsUpdateableThrowApiException()
     {
-        $this->expectException(\Xendit\Exceptions\ApiExceptions::class);
+        $this->expectException(\Xendit\Exceptions\ApiException::class);
 
         $params = ['suggested_amount' => 10000];
 

--- a/tests/Xendit/VirtualAccountTest.php
+++ b/tests/Xendit/VirtualAccountTest.php
@@ -60,7 +60,7 @@ class VirtualAccountTest extends TestCase
      * Should pass
      *
      * @return void
-     * @throws \Xendit\Exceptions\ApiExceptions
+     * @throws \Xendit\Exceptions\ApiException
      */
     public function testVABanksIsGettable()
     {
@@ -136,7 +136,7 @@ class VirtualAccountTest extends TestCase
      * Should pass
      *
      * @return void
-     * @throws \Xendit\Exceptions\ApiExceptions
+     * @throws \Xendit\Exceptions\ApiException
      */
     public function testIsGettableFVAPayment()
     {
@@ -178,7 +178,7 @@ class VirtualAccountTest extends TestCase
      */
     public function testIsVAGettableThrowApiException()
     {
-        $this->expectException(\Xendit\Exceptions\ApiExceptions::class);
+        $this->expectException(\Xendit\Exceptions\ApiException::class);
 
         VirtualAccounts::retrieve(self::TEST_RESOURCE_ID);
     }
@@ -191,7 +191,7 @@ class VirtualAccountTest extends TestCase
      */
     public function testIsUpdateableThrowApiException()
     {
-        $this->expectException(\Xendit\Exceptions\ApiExceptions::class);
+        $this->expectException(\Xendit\Exceptions\ApiException::class);
 
         VirtualAccounts::update(self::TEST_RESOURCE_ID);
     }
@@ -201,11 +201,11 @@ class VirtualAccountTest extends TestCase
      * Should throw ApiException
      *
      * @return void
-     * @throws \Xendit\Exceptions\ApiExceptions
+     * @throws \Xendit\Exceptions\ApiException
      */
     public function testIsFVAPaymentGettableThrowApiException()
     {
-        $this->expectException(\Xendit\Exceptions\ApiExceptions::class);
+        $this->expectException(\Xendit\Exceptions\ApiException::class);
 
         VirtualAccounts::getFVAPayment(self::TEST_RESOURCE_ID);
     }


### PR DESCRIPTION
- Rename `ApiExceptions` to `ApiException`
- Add a property `errorCode` as a representation for Xendit API error code.
- Add a getter for `errorCode`
- Now when creating exception, HTTP error code is inserted as `code`

Resolves #58 