### PR TITLE
fix(http_client): Fix syntax of array assignment to variable and remove getHttpClient return type

### DIFF
--- a/src/ApiRequestor.php
+++ b/src/ApiRequestor.php
@@ -79,13 +79,17 @@ class ApiRequestor
     private function _requestRaw($method, $url, $params, $headers)
     {
         $defaultHeaders = self::_setDefaultHeaders($headers);
-
-        [$rbody, $rcode, $rheaders] = $this->_httpClient()->sendRequest(
+        
+        $response = $this->_httpClient()->sendRequest(
             $method,
             $url,
             $defaultHeaders,
             $params
         );
+
+        $rbody = $response[0];
+        $rcode = $response[1];
+        $rheaders = $response[2];
 
         return [$rbody, $rcode, $rheaders];
     }

--- a/src/HttpClient/GuzzleClient.php
+++ b/src/HttpClient/GuzzleClient.php
@@ -88,7 +88,11 @@ class GuzzleClient implements ClientInterface
         $opts['headers'] = $defaultHeaders;
         $opts['params'] = $params;
 
-        [$rbody, $rcode, $rheader] = $this->_executeRequest($opts, $url);
+        $response = $this->_executeRequest($opts, $url);
+        
+        $rbody = $response[0];
+        $rcode = $response[1];
+        $rheader = $response[2];
 
         return [$rbody, $rcode, $rheader];
     }

--- a/src/Xendit.php
+++ b/src/Xendit.php
@@ -122,7 +122,7 @@ class Xendit
      *
      * @return HttpClientInterface
      */
-    public static function getHttpClient(): ?HttpClientInterface
+    public static function getHttpClient()
     {
         return self::$_httpClient;
     }


### PR DESCRIPTION
Resolves https://github.com/xendit/xendit-php/issues/78

Nullable return type does not work in PHP 7.3, so we removed it.