### PR TITLE
feat: add ApiValidationException to handle API_VALIDATION_ERROR

### DIFF
--- a/README.md
+++ b/README.md
@@ -58,6 +58,7 @@ This library is the abstraction of Xendit API for access from applications writt
 -   [Exceptions](#exceptions)
     -   [InvalidArgumentException](#invalidargumentexception)
     -   [ApiException](#apiexception)
+    -   [ApiValidationException](#apivalidationexception)
 -   [Contributing](#contributing)
     -   [Test](#tests)
         -   [Running test suite](#running-test-suite)
@@ -925,6 +926,23 @@ try {
     $getInvoice = \Xendit\Invoice::retrieve('123');
 } catch (\Xendit\Exceptions\ApiException $e) {
     var_dump($e->getErrorCode());
+}
+```
+
+### ApiValidationException
+
+`ApiValidationException` is the subset of [`ApiException`](#apiexception) that will be thrown in case of invalid parameters in the requests. Compared to `ApiException`, `ApiValidationException` has additional information of the list of invalid parameters and the reason why they are invalid.
+
+To get the list of invalid parameters:
+
+```php
+try {
+    $getInvoice = \Xendit\EWallets::create($params);
+} catch (\Xendit\Exceptions\ApiValidationException $e) {
+    foreach ($e->getValidationErrors() as $validationError) {
+        var_dump($validationError->getPath()); // the location of the invalid parameter in the request
+        var_dump($validationError->getMessage()); // the reason why the parameter is invalid
+    }
 }
 ```
 

--- a/src/Exceptions/ApiValidationException.php
+++ b/src/Exceptions/ApiValidationException.php
@@ -1,0 +1,53 @@
+<?php
+
+/**
+ * ApiValidationExceptionErrors.php
+ * php version 7.2.0
+ *
+ * @category Exception
+ * @package  Xendit\Exceptions
+ * @author   Rifad <rifad@xendit.co>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ * @link     https://api.xendit.co
+ */
+
+namespace Xendit\Exceptions;
+
+/**
+ * Class ApiValidationException
+ *
+ * @category Exception
+ * @package  Xendit\Exceptions
+ * @author   Rifad <rifad@xendit.co>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ * @link     https://api.xendit.co
+ */
+class ApiValidationException extends ApiException
+{
+    protected $validationErrors;
+
+    /**
+     * ApiValidationException constructor.
+     *
+     * @param string $message   corresponds to message field in Xendit's HTTP error
+     * @param string $code      corresponds to http status in Xendit's HTTP response
+     * @param string $errorCode corresponds to error_code field in Xendit's HTTP error
+     * @param array $errors     corresponds to the array of validation errors in Xendit's HTTP response body
+     */
+    public function __construct($message, $code, $errorCode, $errors)
+    {
+        parent::__construct($message, $code, $errorCode);
+
+        $this->validationErrors = $errors;
+    }
+
+    /**
+     * Get the list of validation errors
+     *
+     * @return ApiValidationExceptionErrors[]
+     */
+    public function getValidationErrors()
+    {
+        return $this->validationErrors;
+    }
+}

--- a/src/Exceptions/ApiValidationExceptionErrors.php
+++ b/src/Exceptions/ApiValidationExceptionErrors.php
@@ -1,0 +1,67 @@
+<?php
+
+/**
+ * ApiValidationException.php
+ * php version 7.2.0
+ *
+ * @category Exception
+ * @package  Xendit\Exceptions
+ * @author   Rifad <rifad@xendit.co>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ * @link     https://api.xendit.co
+ */
+
+namespace Xendit\Exceptions;
+
+/**
+ * Class ApiValidationExceptionErrors
+ *
+ * @category Class
+ * @package  Xendit\Exceptions
+ * @author   Rifad <rifad@xendit.co>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ * @link     https://api.xendit.co
+ */
+class ApiValidationExceptionErrors
+{
+    protected $path;
+
+    protected $message;
+
+    /**
+     * ApiValidationExceptionErrors constructor.
+     *
+     * @param string $path      corresponds to the location of the invalid parameter in the request
+     * @param string $message   corresponds to the reason why the parameter is invalid
+     */
+    public function __construct($path, $message)
+    {
+        $this->path    = $path;
+        $this->message = $message;
+    }
+
+    /**
+     * Get the location of the invalid parameter in the request
+     *
+     * @return string
+     */
+    public function getPath()
+    {
+        return $this->path;
+    }
+
+    /**
+     * Get the reason why the parameter is invalid
+     *
+     * @return string
+     */
+    public function getMessage()
+    {
+        return $this->message;
+    }
+
+    public function __toString()
+    {
+        return $this->path . ': ' . $this->message;
+    }
+}


### PR DESCRIPTION
Currently when API returns `API_VALIDATION_ERROR`, there is no way for the caller to access the `errors` field in the response body which contains the information of which parameters that are invalid and the reason why they're marked as invalid.