### PR TITLE
hotfix query in GET method

### DIFF
--- a/examples/TransactionExample.php
+++ b/examples/TransactionExample.php
@@ -15,10 +15,14 @@ use Xendit\Xendit;
 
 require 'vendor/autoload.php';
 
-Xendit::setApiKey('SECRET_API_KEY');
+Xendit::setApiKey('xnd_development_gpa2q6CoWVCjjGHpFDynTaizO6AkmvUrn1VrkMWAcsIujh2AfhC2PSlrceKOXS');
 
-$list = \Xendit\Transaction::list();
+$params = [
+    'types' => 'DISBURSEMENT',
+    'for-user-id' => '6151d0a19770efbe7fb712b8',
+];
+$list = \Xendit\Transaction::list($params);
 var_dump($list);
 
-$detail = \Xendit\Transaction::detail('txn_13dd178d-41fa-40b7-8fd3-f83675d6f413');
-var_dump($detail);
+// $detail = \Xendit\Transaction::detail('txn_13dd178d-41fa-40b7-8fd3-f83675d6f413');
+// var_dump($detail);

--- a/examples/TransactionExample.php
+++ b/examples/TransactionExample.php
@@ -24,5 +24,5 @@ $params = [
 $list = \Xendit\Transaction::list($params);
 var_dump($list);
 
-// $detail = \Xendit\Transaction::detail('txn_13dd178d-41fa-40b7-8fd3-f83675d6f413');
-// var_dump($detail);
+$detail = \Xendit\Transaction::detail('txn_13dd178d-41fa-40b7-8fd3-f83675d6f413');
+var_dump($detail);

--- a/examples/TransactionExample.php
+++ b/examples/TransactionExample.php
@@ -15,7 +15,7 @@ use Xendit\Xendit;
 
 require 'vendor/autoload.php';
 
-Xendit::setApiKey('xnd_development_gpa2q6CoWVCjjGHpFDynTaizO6AkmvUrn1VrkMWAcsIujh2AfhC2PSlrceKOXS');
+Xendit::setApiKey('SECRET_API_KEY');
 
 $params = [
     'types' => 'DISBURSEMENT',

--- a/src/ApiOperations/Request.php
+++ b/src/ApiOperations/Request.php
@@ -67,18 +67,22 @@ trait Request
 
         if (array_key_exists('for-user-id', $params)) {
             $headers['for-user-id'] = $params['for-user-id'];
+            unset($params['for-user-id']);
         }
 
         if (array_key_exists('with-fee-rule', $params)) {
             $headers['with-fee-rule'] = $params['with-fee-rule'];
+            unset($params['with-fee-rule']);
         }
 
         if (array_key_exists('Idempotency-key', $params)) {
             $headers['Idempotency-key'] = $params['Idempotency-key'];
+            unset($params['Idempotency-key']);
         }
 
         if (array_key_exists('X-IDEMPOTENCY-KEY', $params)) {
             $headers['X-IDEMPOTENCY-KEY'] = $params['X-IDEMPOTENCY-KEY'];
+            unset($params['X-IDEMPOTENCY-KEY']);
         }
 
         if (array_key_exists('api-version', $params)) {
@@ -88,6 +92,7 @@ trait Request
 
         if (array_key_exists('X-API-VERSION', $params)) {
             $headers['X-API-VERSION'] = $params['X-API-VERSION'];
+            unset($params['X-API-VERSION']);
         }
 
         $requestor = new \Xendit\ApiRequestor();

--- a/src/ApiOperations/Request.php
+++ b/src/ApiOperations/Request.php
@@ -67,22 +67,18 @@ trait Request
 
         if (array_key_exists('for-user-id', $params)) {
             $headers['for-user-id'] = $params['for-user-id'];
-            unset($params['for-user-id']);
         }
 
         if (array_key_exists('with-fee-rule', $params)) {
             $headers['with-fee-rule'] = $params['with-fee-rule'];
-            unset($params['with-fee-rule']);
         }
 
         if (array_key_exists('Idempotency-key', $params)) {
             $headers['Idempotency-key'] = $params['Idempotency-key'];
-            unset($params['Idempotency-key']);
         }
 
         if (array_key_exists('X-IDEMPOTENCY-KEY', $params)) {
             $headers['X-IDEMPOTENCY-KEY'] = $params['X-IDEMPOTENCY-KEY'];
-            unset($params['X-IDEMPOTENCY-KEY']);
         }
 
         if (array_key_exists('api-version', $params)) {
@@ -92,7 +88,6 @@ trait Request
 
         if (array_key_exists('X-API-VERSION', $params)) {
             $headers['X-API-VERSION'] = $params['X-API-VERSION'];
-            unset($params['X-API-VERSION']);
         }
 
         $requestor = new \Xendit\ApiRequestor();

--- a/src/HttpClient/GuzzleClient.php
+++ b/src/HttpClient/GuzzleClient.php
@@ -114,6 +114,29 @@ class GuzzleClient implements ClientInterface
         try {
             if (count($params) > 0) {
                 if (strtoupper($opts['method']) === 'GET') {
+                    if (array_key_exists('for-user-id', $params)) {
+                        unset($params['for-user-id']);
+                    }
+
+                    if (array_key_exists('with-fee-rule', $params)) {
+                        unset($params['with-fee-rule']);
+                    }
+
+                    if (array_key_exists('Idempotency-key', $params)) {
+                        unset($params['Idempotency-key']);
+                    }
+
+                    if (array_key_exists('X-IDEMPOTENCY-KEY', $params)) {
+                        unset($params['X-IDEMPOTENCY-KEY']);
+                    }
+
+                    if (array_key_exists('api-version', $params)) {
+                        unset($params['api-version']);
+                    }
+
+                    if (array_key_exists('X-API-VERSION', $params)) {
+                        unset($params['X-API-VERSION']);
+                    }
                     $response =  $this->http->request(
                         $opts['method'], $url, [
                             'auth' => [$apiKey, ''],

--- a/src/HttpClient/GuzzleClient.php
+++ b/src/HttpClient/GuzzleClient.php
@@ -113,13 +113,23 @@ class GuzzleClient implements ClientInterface
         $url = strval($url);
         try {
             if (count($params) > 0) {
-                $response =  $this->http->request(
-                    $opts['method'], $url, [
-                        'auth' => [$apiKey, ''],
-                        'headers' => $headers,
-                        RequestOptions::JSON => $params
-                    ]
-                );
+                if (strtoupper($opts['method']) === 'GET') {
+                    $response =  $this->http->request(
+                        $opts['method'], $url, [
+                            'auth' => [$apiKey, ''],
+                            'headers' => $headers,
+                            'query' => $params
+                        ]
+                    );
+                } else {
+                    $response =  $this->http->request(
+                        $opts['method'], $url, [
+                            'auth' => [$apiKey, ''],
+                            'headers' => $headers,
+                            RequestOptions::JSON => $params
+                        ]
+                    );
+                }
             } else {
                 $response =  $this->http->request(
                     $opts['method'], $url, [


### PR DESCRIPTION
Got the critical issue when we use GET method and pass the query parameters. query do not pass in guzzle side coz default library process the params to transform into json. But in GET method, we need to transform params into query not json.

eg is: 
```php
$params = [
    'types' => 'DISBURSEMENT'
];

$transactions = \Xendit\Transaction::list(array $params);
```

the params is not working cos `Transaction::list` using GET method and params tranform into json not into query