### PR TITLE
Fix/guzzle client accept query param

### DIFF
--- a/README.md
+++ b/README.md
@@ -1328,6 +1328,8 @@ Usage example:
 ```php
 $params = [
     'types' => 'DISBURSEMENT'
+    'for-user-id' => 'Your User Id', //Optional
+    'query-param'=> 'true' //This is to enable parameters as query strings
 ];
 
 $transactions = \Xendit\Transaction::list(array $params);

--- a/composer.json
+++ b/composer.json
@@ -1,7 +1,7 @@
 {
     "name": "xendit/xendit-php",
     "description": "PHP clients for Xendit API",
-    "version": "2.13.0",
+    "version": "2.14.0",
     "license": "MIT",
     "keywords": [
         "xendit"

--- a/composer.lock
+++ b/composer.lock
@@ -4,7 +4,7 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#installing-dependencies",
         "This file is @generated automatically"
     ],
-    "content-hash": "b0b360ce0d5bd36f31397c8fbe0622ce",
+    "content-hash": "46d6f7b61c42dde2c200324074d82fad",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",

--- a/examples/TransactionExample.php
+++ b/examples/TransactionExample.php
@@ -16,8 +16,12 @@ use Xendit\Xendit;
 require 'vendor/autoload.php';
 
 Xendit::setApiKey('SECRET_API_KEY');
-
-$list = \Xendit\Transaction::list();
+$params = [
+    'types' => 'DISBURSEMENT',
+    'for-user-id' => '<your user id>',
+    'query-param'=> 'true'
+];
+$list = \Xendit\Transaction::list($params);
 var_dump($list);
 
 $detail = \Xendit\Transaction::detail('txn_13dd178d-41fa-40b7-8fd3-f83675d6f413');

--- a/src/HttpClient/GuzzleClient.php
+++ b/src/HttpClient/GuzzleClient.php
@@ -113,11 +113,15 @@ class GuzzleClient implements ClientInterface
         $url = strval($url);
         try {
             if (count($params) > 0) {
+                $isQueryParam = isset($params['query-param']) && $params['query-param'] === 'true'; // additional condition to check if the requestor is imposing query param, otherwise default json
+                
+                if($isQueryParam) unset($params['query-param']);
+                
                 $response =  $this->http->request(
                     $opts['method'], $url, [
                         'auth' => [$apiKey, ''],
                         'headers' => $headers,
-                        RequestOptions::JSON => $params
+                        $isQueryParam ? RequestOptions::QUERY : RequestOptions::JSON => $params
                     ]
                 );
             } else {


### PR DESCRIPTION
**To fix transaction API**

1. To fix transaction API which requires query string as parameters.
2. Enable option to turn on query parameter with new identifier 'query-param' and add a check in guzzle client
3. Update version to 2.14.0