### PR TITLE
Add Refunds class and improve php 7.3 coverage

### DIFF
--- a/.github/workflows/php.yml
+++ b/.github/workflows/php.yml
@@ -23,7 +23,7 @@ jobs:
 
     - name: Cache Composer packages
       id: composer-cache
-      uses: actions/cache@v2
+      uses: actions/cache@v3.2.6
       with:
         path: vendor
         key: ${{ runner.os }}-php-${{ hashFiles('**/composer.lock') }}

--- a/examples/CustomHttpClient.php
+++ b/examples/CustomHttpClient.php
@@ -25,7 +25,7 @@ class HttpCliImp implements HttpClientInterface {
     {
         $this->_guzz = $guzz;
     }
-    public function request($method, $uri, array $options = [])
+    public function request(string $method, $uri, array $options = [])
     {
         return $this->_guzz->request($method, $uri, $options);
     }

--- a/examples/RefundExample.php
+++ b/examples/RefundExample.php
@@ -1,0 +1,27 @@
+<?php
+
+use Xendit\Xendit;
+
+require 'vendor/autoload.php';
+
+Xendit::setApiKey('SECRET_API_KEY');
+
+$params = [
+    'id' => 'xx-Example',
+    'payment_request_id' => 'samp-2232323',
+    'reference_id' => 'ref-23232m23n',
+    'invoice_id' => 'inv-232323232',
+    'currency' => "IDR",
+    'amount' => 30000,
+    'reason' => 'Cancel Payment',
+    'metadata' => null
+];
+
+$createRefund = \Xendit\Refund::create($params);
+var_dump($createRefund);
+
+$retrieveRefund = \Xendit\Refund::retrieve($params['id']);
+var_dump($retrieveRefund);
+
+$retrieveAllRefund = \Xendit\Refund::retrieveAll();
+var_dump($retrieveAllRefund);

--- a/src/ApiOperations/Create.php
+++ b/src/ApiOperations/Create.php
@@ -31,7 +31,7 @@ trait Create
      *
      * @return array
      */
-    public static function create($params = [])
+    public static function create(array $params = []): array
     {
         self::validateParams($params, static::createReqParams());
 

--- a/src/ApiOperations/Request.php
+++ b/src/ApiOperations/Request.php
@@ -34,7 +34,7 @@ trait Request
      *
      * @return void
      */
-    protected static function validateParams($params = [], $requiredParams = [])
+    protected static function validateParams(array $params = [], array $requiredParams = [])
     {
         $currParams = array_diff_key(array_flip($requiredParams), $params);
         if ($params && !is_array($params)) {
@@ -59,10 +59,11 @@ trait Request
      * @throws \Xendit\Exceptions\ApiException
      */
     protected static function _request(
-        $method,
-        $url,
-        $params = []
-    ) {
+        string $method,
+        string $url,
+        array $params = []
+    ): array
+    {
         $headers = [];
 
         if (array_key_exists('for-user-id', $params)) {
@@ -94,7 +95,7 @@ trait Request
             $headers['X-API-VERSION'] = $params['X-API-VERSION'];
         }
 
-        $requestor = new \Xendit\ApiRequestor();
-        return $requestor->request($method, $url, $params, $headers);
+        $requester = new \Xendit\ApiRequestor();
+        return $requester->request($method, $url, $params, $headers);
     }
 }

--- a/src/ApiOperations/Retrieve.php
+++ b/src/ApiOperations/Retrieve.php
@@ -28,10 +28,10 @@ trait Retrieve
      * Send GET request to retrieve data
      *
      * @param string|null $id ID
-     *
+     * @param array $params
      * @return array
      */
-    public static function retrieve($id, $params = [])
+    public static function retrieve(?string $id, array $params = []): array
     {
         $url = static::classUrl() . '/' . $id;
         return static::_request('GET', $url, $params);

--- a/src/ApiOperations/RetrieveAll.php
+++ b/src/ApiOperations/RetrieveAll.php
@@ -27,9 +27,10 @@ trait RetrieveAll
     /**
      * Send request to get all object, e.g Invoice
      *
+     * @param array $params
      * @return array
      */
-    public static function retrieveAll($params = [])
+    public static function retrieveAll(array $params = []): array
     {
         $url = static::classUrl();
         return static::_request('GET', $url, $params);

--- a/src/ApiOperations/Update.php
+++ b/src/ApiOperations/Update.php
@@ -28,11 +28,11 @@ trait Update
      * Send an update request
      *
      * @param string $id     data ID
-     * @param array  $params user's params
+     * @param array $params user's params
      *
      * @return array
      */
-    public static function update($id, $params = [])
+    public static function update(string $id, array $params = []): array
     {
         self::validateParams($params, static::updateReqParams());
 

--- a/src/ApiRequestor.php
+++ b/src/ApiRequestor.php
@@ -31,13 +31,13 @@ class ApiRequestor
      *
      * @param string $method  request method (get, post, patch, etc)
      * @param string $url     base url
-     * @param array  $params  user's params
-     * @param array  $headers user's additional headers
+     * @param array $params  user's params
+     * @param array $headers user's additional headers
      *
      * @return array
      * @throws Exceptions\ApiException
      */
-    public function request($method, $url, $params = [], $headers = [])
+    public function request(string $method, string $url, array $params = [], array $headers = []): array
     {
         list($rbody, $rcode, $rheaders)
             = $this->_requestRaw($method, $url, $params, $headers);

--- a/src/Balance.php
+++ b/src/Balance.php
@@ -33,7 +33,7 @@ class Balance
      *
      * @return array
      */
-    public static function accountType()
+    public static function accountType(): array
     {
         return ["CASH", "HOLDING", "TAX"];
     }
@@ -41,11 +41,11 @@ class Balance
     /**
      * Validation for account type
      *
-     * @param string $account_type Account type
+     * @param string|null $account_type Account type
      *
      * @return void
      */
-    public static function validateAccountType($account_type = null)
+    public static function validateAccountType(string $account_type = null)
     {
         if (!in_array($account_type, self::accountType())) {
             $msg = "Account type is invalid. Available types: CASH, TAX, HOLDING";
@@ -56,14 +56,14 @@ class Balance
     /**
      * Send GET request to retrieve data
      *
-     * @param string $account_type account type (CASH|HOLDING|TAX)
+     * @param string|null $account_type account type (CASH|HOLDING|TAX)
      *
      * @return array[
      *  'balance' => int
      * ]
      * @throws Exceptions\ApiException
      */
-    public static function getBalance($account_type = null, $params = [])
+    public static function getBalance(string $account_type = null, $params = []): array
     {
         self::validateAccountType($account_type);
         $url = '/balance?account_type=' . $account_type;

--- a/src/CardlessCredit.php
+++ b/src/CardlessCredit.php
@@ -32,7 +32,7 @@ class CardlessCredit
      *
      * @return string
      */
-    public static function classUrl()
+    public static function classUrl(): string
     {
         return "/cardless-credit";
     }
@@ -42,7 +42,7 @@ class CardlessCredit
      *
      * @return array
      */
-    public static function createReqParams()
+    public static function createReqParams(): array
     {
         return [
             'cardless_credit_type',
@@ -64,9 +64,9 @@ class CardlessCredit
      *
      * @return array
      *
-     * @throws ApiException
+     * @throws ApiException|\Xendit\Exceptions\ApiException
      */
-    public static function calculatePaymentTypes($params = [])
+    public static function calculatePaymentTypes(array $params = []): array
     {
         $requiredParams = [
             'cardless_credit_type',

--- a/src/Cards.php
+++ b/src/Cards.php
@@ -33,7 +33,7 @@ class Cards
      *
      * @return string
      */
-    public static function classUrl()
+    public static function classUrl(): string
     {
         return "/credit_card_charges";
     }
@@ -43,7 +43,7 @@ class Cards
      * for more details
      *
      * @param string $id     charge ID
-     * @param array  $params user parameters
+     * @param array $params user parameters
      *
      * @return array [
      *  'created' => string,
@@ -64,7 +64,7 @@ class Cards
      * ]
      * @throws Exceptions\ApiException
      */
-    public static function capture($id, $params = [])
+    public static function capture(string $id, array $params = []): array
     {
         $url = self::classUrl() . '/' . $id . '/capture';
         $requiredParams = ['amount'];
@@ -79,7 +79,7 @@ class Cards
      *
      * @return array
      */
-    public static function createReqParams()
+    public static function createReqParams(): array
     {
         return ['token_id', 'external_id', 'amount'];
     }
@@ -88,7 +88,7 @@ class Cards
      * Reverse authorized charge
      *
      * @param string $id     charge ID
-     * @param array  $params user params
+     * @param array $params user params
      *
      * @return array [
      *  'created' => string,
@@ -101,7 +101,7 @@ class Cards
      * ]
      * @throws Exceptions\ApiException
      */
-    public static function reverseAuthorization($id, $params = [])
+    public static function reverseAuthorization(string $id, array $params = []): array
     {
         $url = self::classUrl() . '/' . $id . '/auth_reversal';
         $requiredParams = ['external_id'];
@@ -116,7 +116,7 @@ class Cards
      * for more details
      *
      * @param string $id     charge ID
-     * @param array  $params user parameters
+     * @param array $params user parameters
      *
      * @return array [
      *  'updated' => string,
@@ -131,7 +131,7 @@ class Cards
      * ]
      * @throws Exceptions\ApiException
      */
-    public static function createRefund($id, $params = [])
+    public static function createRefund(string $id, array $params = []): array
     {
         $url = self::classUrl() . '/' . $id . '/refunds';
         $requiredParams = ['amount', 'external_id'];

--- a/src/Customers.php
+++ b/src/Customers.php
@@ -33,7 +33,7 @@ class Customers
      *
      * @return string
      */
-    public static function classUrl()
+    public static function classUrl(): string
     {
         return "/customers";
     }
@@ -47,7 +47,7 @@ class Customers
      * https://developers.xendit.co/api-reference/?bash#create-customer
      * @throws Exceptions\ApiException
      */
-    public static function createCustomer($params = [])
+    public static function createCustomer(array $params = []): array
     {
         $requiredParams = ['reference_id'];
 
@@ -61,13 +61,13 @@ class Customers
                 'kyc_documents'
             );
         } else {
-            array_push($requiredParams, 'given_names');
+            $requiredParams[] = 'given_names';
             if (!array_key_exists('mobile_number', $params)) {
-                array_push($requiredParams, 'email');
+                $requiredParams[] = 'email';
             }
 
             if (!array_key_exists('email', $params)) {
-                array_push($requiredParams, 'mobile_number');
+                $requiredParams[] = 'mobile_number';
             }
         }
 
@@ -82,13 +82,13 @@ class Customers
      * Get customer by reference ID
      *
      * @param string $reference_id reference ID
-     * @param array  $params       user's parameters
+     * @param array $params user's parameters
      *
      * @return array please check for responses parameters here
      * https://developers.xendit.co/api-reference/?bash#get-customer-by-reference-id
      * @throws Exceptions\ApiException
      */
-    public static function getCustomerByReferenceID($reference_id, $params=[])
+    public static function getCustomerByReferenceID(string $reference_id, array $params = []): array
     {
         $url = static::classUrl()
             . '?reference_id=' . $reference_id;

--- a/src/DirectDebit.php
+++ b/src/DirectDebit.php
@@ -33,7 +33,7 @@ class DirectDebit
      *
      * @return string
      */
-    public static function linkedAccountUrl()
+    public static function linkedAccountUrl(): string
     {
         return "/linked_account_tokens/";
     }
@@ -43,7 +43,7 @@ class DirectDebit
      *
      * @return string
      */
-    public static function paymentMethodUrl()
+    public static function paymentMethodUrl(): string
     {
         return "/payment_methods";
     }
@@ -53,13 +53,13 @@ class DirectDebit
      *
      * @return string
      */
-    public static function directDebitPaymentUrl()
+    public static function directDebitPaymentUrl(): string
     {
         return "/direct_debits";
     }
 
     /**
-     * Send a initialize linked account tokenization request
+     * Send an initialize linked account tokenization request
      *
      * @param array $params user's parameters
      *
@@ -67,7 +67,7 @@ class DirectDebit
      * https://developers.xendit.co/api-reference/?bash#initialize-linked-account-tokenization
      * @throws Exceptions\ApiException
      */
-    public static function initializeLinkedAccountTokenization($params = [])
+    public static function initializeLinkedAccountTokenization(array $params = []): array
     {
         $requiredParams = ['customer_id', 'channel_code'];
 
@@ -79,19 +79,20 @@ class DirectDebit
     }
 
     /**
-     * Send a validate OTP for linked account request
+     * Send a validated OTP for linked account request
      *
      * @param string $linked_account_token_id linked account token ID
-     * @param array  $params                  user's parameters
+     * @param array $params                  user's parameters
      *
      * @return array please check for responses parameters here
      * https://developers.xendit.co/api-reference/?bash#validate-otp-for-linked-account-token
      * @throws Exceptions\ApiException
      */
     public static function validateOTPForLinkedAccount(
-        $linked_account_token_id,
-        $params = []
-    ) {
+        string $linked_account_token_id,
+        array $params = []
+    ): array
+    {
         $requiredParams = ['otp_code'];
 
         self::validateParams($params, $requiredParams);
@@ -111,7 +112,7 @@ class DirectDebit
      * https://developers.xendit.co/api-reference/?bash#retrieve-accessible-accounts-by-linked-account-token
      * @throws Exceptions\ApiException
      */
-    public static function retrieveAccessibleLinkedAccounts($linked_account_token_id)
+    public static function retrieveAccessibleLinkedAccounts(string $linked_account_token_id): array
     {
         $url = static::linkedAccountUrl() . $linked_account_token_id . "/accounts";
 
@@ -127,7 +128,7 @@ class DirectDebit
      * https://developers.xendit.co/api-reference/?bash#unbind-a-linked-account-token
      * @throws Exceptions\ApiException
      */
-    public static function unbindLinkedAccountToken($linked_account_token_id)
+    public static function unbindLinkedAccountToken(string $linked_account_token_id): array
     {
         $url = static::linkedAccountUrl() . $linked_account_token_id;
 
@@ -143,7 +144,7 @@ class DirectDebit
      * https://developers.xendit.co/api-reference/?bash#create-payment-method
      * @throws Exceptions\ApiException
      */
-    public static function createPaymentMethod($params = [])
+    public static function createPaymentMethod(array $params = []): array
     {
         $requiredParams = ['type', 'properties'];
 
@@ -163,7 +164,7 @@ class DirectDebit
      * https://developers.xendit.co/api-reference/?bash#list-payment-methods
      * @throws Exceptions\ApiException
      */
-    public static function getPaymentMethodsByCustomerID($customer_id)
+    public static function getPaymentMethodsByCustomerID(string $customer_id): array
     {
         $url = static::paymentMethodUrl() . "?customer_id=" . $customer_id;
 
@@ -179,7 +180,7 @@ class DirectDebit
      * https://developers.xendit.co/api-reference/?bash#create-direct-debit-payment
      * @throws Exceptions\ApiException
      */
-    public static function createDirectDebitPayment($params = [])
+    public static function createDirectDebitPayment(array $params = []): array
     {
         $requiredParams = [
             'reference_id',
@@ -199,16 +200,17 @@ class DirectDebit
      * Send a validate OTP for direct debit payment
      *
      * @param string $direct_debit_payment_id direct debit payment ID
-     * @param array  $params                  user's parameters
+     * @param array $params                  user's parameters
      *
      * @return array please check for responses parameters here
      * https://developers.xendit.co/api-reference/?bash#validate-otp-for-direct-debit-payment
      * @throws Exceptions\ApiException
      */
     public static function validateOTPForDirectDebitPayment(
-        $direct_debit_payment_id,
-        $params = []
-    ) {
+        string $direct_debit_payment_id,
+        array $params = []
+    ): array
+    {
         $requiredParams = ['otp_code'];
 
         self::validateParams($params, $requiredParams);
@@ -228,7 +230,7 @@ class DirectDebit
      * https://developers.xendit.co/api-reference/?bash#get-payment-by-id
      * @throws Exceptions\ApiException
      */
-    public static function getDirectDebitPaymentByID($direct_debit_payment_id)
+    public static function getDirectDebitPaymentByID(string $direct_debit_payment_id): array
     {
         $url = static::directDebitPaymentUrl() . "/" . $direct_debit_payment_id .
                "/";
@@ -245,7 +247,7 @@ class DirectDebit
      * https://developers.xendit.co/api-reference/?bash#get-payment-by-reference-id
      * @throws Exceptions\ApiException
      */
-    public static function getDirectDebitPaymentByReferenceID($reference_id)
+    public static function getDirectDebitPaymentByReferenceID(string $reference_id): array
     {
         $url = static::directDebitPaymentUrl() . "?reference_id=" . $reference_id;
 

--- a/src/DisbursementChannels.php
+++ b/src/DisbursementChannels.php
@@ -13,6 +13,8 @@
 
 namespace Xendit;
 
+use PhpOption\None;
+
 /**
  * Class DisbursementChannels
  *
@@ -33,15 +35,13 @@ class DisbursementChannels
      *
      * @return string
      */
-    public static function classUrl()
+    public static function classUrl(): string
     {
         return '/disbursement-channels';
     }
 
     /**
      * Send GET request to Get Disbursement Channels
-     *
-     * @param none
      *
      * @return array[
      * [
@@ -63,9 +63,8 @@ class DisbursementChannels
      * ]]
      * @throws Exceptions\ApiException
      */
-    public static function getDisbursementChannels()
+    public static function getDisbursementChannels(): array
     {
-        $url = '/disbursement-channels';
         return static::_request('GET', static::classUrl());
     }
 
@@ -95,7 +94,7 @@ class DisbursementChannels
      * ]]
      * @throws Exceptions\ApiException
      */
-    public static function getDisbursementChannelsByChannelCategory($channel_category, $params = [])
+    public static function getDisbursementChannelsByChannelCategory(string $channel_category, array $params = []): array
     {
         $url = static::classUrl() . '?channel_category=' . $channel_category;
         return static::_request('GET', $url, $params);
@@ -119,7 +118,7 @@ class DisbursementChannels
      * ]]
      * @throws Exceptions\ApiException
      */
-    public static function getDisbursementChannelsByChannelCode($channel_code, $params = [])
+    public static function getDisbursementChannelsByChannelCode(string $channel_code, array $params = []): array
     {
         $url = static::classUrl() . '?channel_code=' . $channel_code;
         return static::_request('GET', $url, $params);

--- a/src/Disbursements.php
+++ b/src/Disbursements.php
@@ -33,7 +33,7 @@ class Disbursements
      *
      * @return string
      */
-    public static function classUrl()
+    public static function classUrl(): string
     {
         return '/disbursements';
     }
@@ -43,7 +43,7 @@ class Disbursements
      *
      * @return array
      */
-    public static function createReqParams()
+    public static function createReqParams(): array
     {
         return [
             'external_id',
@@ -70,7 +70,7 @@ class Disbursements
      * ]
      * @throws Exceptions\ApiException
      */
-    public static function createBatch($params = [])
+    public static function createBatch(array $params = []): array
     {
         $requiredParams = ['reference', 'disbursements'];
 
@@ -112,7 +112,7 @@ class Disbursements
      * ]
      * @throws Exceptions\ApiException
      */
-    public static function retrieveExternal($external_id, $params = [])
+    public static function retrieveExternal(string $external_id, array $params = []): array
     {
         $url = static::classUrl() . '?external_id=' . $external_id;
         return static::_request('GET', $url, $params);
@@ -140,7 +140,7 @@ class Disbursements
      * ]]
      * @throws Exceptions\ApiException
      */
-    public static function getAvailableBanks()
+    public static function getAvailableBanks(): array
     {
         $url = '/available_disbursements_banks';
         return static::_request('GET', $url);

--- a/src/DisbursementsPHP.php
+++ b/src/DisbursementsPHP.php
@@ -35,7 +35,7 @@ class DisbursementsPHP
      *
      * @return string
      */
-    public static function classUrl()
+    public static function classUrl(): string
     {
         return '/disbursements';
     }
@@ -45,7 +45,7 @@ class DisbursementsPHP
      *
      * @return array
      */
-    public static function createPHPReqParams()
+    public static function createPHPReqParams(): array
     {
         return [
             'xendit-idempotency-key',
@@ -64,7 +64,7 @@ class DisbursementsPHP
      *
      * @return array
      */
-    public static function beneficiaryReqParams()
+    public static function beneficiaryReqParams(): array
     {
         return [
             'type',
@@ -90,7 +90,7 @@ class DisbursementsPHP
      *
      * @return array
      */
-    public static function receiptNotificationReqParams()
+    public static function receiptNotificationReqParams(): array
     {
         return [
             'email_to',
@@ -118,7 +118,7 @@ class DisbursementsPHP
      * beneficiary => Array
      * @throws Exceptions\ApiException
      */
-    public static function createPHPDisbursement($params = [])
+    public static function createPHPDisbursement(array $params = []): array
     {
         self::validateParams($params, static::createPHPReqParams());
         if (array_key_exists('beneficiary', $params)) {
@@ -151,7 +151,7 @@ class DisbursementsPHP
      * beneficiary => Array
      * @throws Exceptions\ApiException
      */
-    public static function getPHPDisbursementByID($disbursement_id, $params = [])
+    public static function getPHPDisbursementByID(string $disbursement_id, array $params = []): array
     {
         $url = static::classUrl() . '/' . $disbursement_id;
         return static::_request('GET', $url, $params);
@@ -191,7 +191,7 @@ class DisbursementsPHP
      * ]]
      * @throws Exceptions\ApiException
      */
-    public static function getPHPDisbursementsByReferenceID($reference_id, $params = [])
+    public static function getPHPDisbursementsByReferenceID(string $reference_id, array $params = []): array
     {
         $url = static::classUrl() . '?reference_id=' . $reference_id;
         return static::_request('GET', $url, $params);

--- a/src/EWallets.php
+++ b/src/EWallets.php
@@ -33,7 +33,7 @@ class EWallets
      *
      * @return string
      */
-    public static function classUrl()
+    public static function classUrl(): string
     {
         return "/ewallets";
     }
@@ -47,7 +47,7 @@ class EWallets
      * https://xendit.github.io/apireference/?bash#create-payment
      * @throws Exceptions\ApiException
      */
-    public static function create($params = [])
+    public static function create(array $params = []): array
     {
         $requiredParams = [];
 
@@ -76,14 +76,14 @@ class EWallets
     /**
      * Get Payment Status
      *
-     * @param string $external_id  external ID
+     * @param string $external_id external ID
      * @param string $ewallet_type E-wallet type (OVO, DANA, LINKAJA
      *
      * @return array please check for responses for each e-wallet type
      * https://xendit.github.io/apireference/?bash#get-payment-status
      * @throws Exceptions\ApiException
      */
-    public static function getPaymentStatus($external_id, $ewallet_type)
+    public static function getPaymentStatus(string $external_id, string $ewallet_type): array
     {
         $url = static::classUrl()
             . '?external_id=' . $external_id
@@ -101,7 +101,7 @@ class EWallets
      * https://developers.xendit.co/api-reference/?bash#create-ewallet-charge
      * @throws Exceptions\ApiException
      */
-    public static function createEWalletCharge($params = [])
+    public static function createEWalletCharge(array $params = []): array
     {
         $requiredParams = ['reference_id', 'currency', 'amount', 'checkout_method'];
 
@@ -121,14 +121,14 @@ class EWallets
      * https://developers.xendit.co/api-reference/?bash#get-ewallet-charge-status
      * @throws Exceptions\ApiException
      */
-    public static function getEWalletChargeStatus($charge_id, $params=[])
+    public static function getEWalletChargeStatus(string $charge_id, array $params = []): array
     {
         $url = static::classUrl()
             . '/charges/' . $charge_id;
 
         return static::_request('GET', $url, $params);
     }
-    
+
     /**
      * Void eWallet Charge
      *
@@ -138,14 +138,14 @@ class EWallets
      * https://developers.xendit.co/api-reference/#void-ewallet-charge
      * @throws Exceptions\ApiException
      */
-    public static function voidEwalletCharge($charge_id, $params=[])
+    public static function voidEwalletCharge(string $charge_id, array $params = []): array
     {
         $url = static::classUrl()
-        . '/charges/' . $charge_id.'/void';
-        
+            . '/charges/' . $charge_id . '/void';
+
         return static::_request('POST', $url, $params);
     }
-    
+
     /**
      * Refund eWallet Charge
      *
@@ -155,14 +155,14 @@ class EWallets
      * https://developers.xendit.co/api-reference/#refund-ewallet-charge
      * @throws Exceptions\ApiException
      */
-    public static function refundEwalletCharge($charge_id, $params=[])
+    public static function refundEwalletCharge(string $charge_id, array $params = []): array
     {
         $url = static::classUrl()
-        . '/charges/' . $charge_id.'/refunds';
-        
+            . '/charges/' . $charge_id . '/refunds';
+
         return static::_request('POST', $url, $params);
     }
-    
+
     /**
      * Get eWallet Refund by Refund ID
      *
@@ -173,14 +173,14 @@ class EWallets
      * https://developers.xendit.co/api-reference/#refund-ewallet-charge
      * @throws Exceptions\ApiException
      */
-    public static function getRefund($charge_id, $refund_id, $params=[])
+    public static function getRefund(string $charge_id, string $refund_id, array $params = []): array
     {
         $url = static::classUrl()
-        . '/charges/' . $charge_id.'/refunds/'.$refund_id;
-        
+            . '/charges/' . $charge_id . '/refunds/' . $refund_id;
+
         return static::_request('GET', $url, $params);
     }
-    
+
     /**
      * Get eWallet Refund by Refund ID
      *
@@ -190,11 +190,11 @@ class EWallets
      * https://developers.xendit.co/api-reference/#refund-ewallet-charge
      * @throws Exceptions\ApiException
      */
-    public static function listRefund($charge_id, $params=[])
+    public static function listRefund($charge_id, $params = [])
     {
         $url = static::classUrl()
-        . '/charges/' . $charge_id.'/refunds/';
-        
+            . '/charges/' . $charge_id . '/refunds/';
+
         return static::_request('GET', $url, $params);
     }
 }

--- a/src/Exceptions/ApiException.php
+++ b/src/Exceptions/ApiException.php
@@ -28,23 +28,24 @@ class ApiException extends \Exception implements ExceptionInterface
 
     /**
      * Get error code for the exception instance
-     * 
+     *
      * @return string
      */
-    public function getErrorCode() 
+    public function getErrorCode(): string
     {
         return $this->errorCode;
     }
 
     /**
      * Create new instance of ApiException
-     * 
-     * @param string $message   corresponds to message field in Xendit's HTTP error
-     * @param string $code      corresponds to http status in Xendit's HTTP response
-     * @param string $errorCode corresponds to error_code field in Xendit's HTTP 
+     *
+     * @param string $message corresponds to message field in Xendit's HTTP error
+     * @param string $code corresponds to http status in Xendit's HTTP response
+     * @param string $errorCode corresponds to error_code field in Xendit's HTTP
      *                          error
+     * @throws \Xendit\Exceptions\ApiException
      */
-    public function __construct($message, $code, $errorCode)
+    public function __construct(string $message, string $code, string $errorCode)
     {
         if (!$message) {
             throw new $this('Unknown '. get_class($this));

--- a/src/Exceptions/ExceptionInterface.php
+++ b/src/Exceptions/ExceptionInterface.php
@@ -26,8 +26,8 @@ interface ExceptionInterface extends \Throwable
 {
     /**
      * Get error code for the exception instance
-     * 
+     *
      * @return string
      */
-    public function getErrorCode();
+    public function getErrorCode(): string;
 }

--- a/src/HttpClient/ClientInterface.php
+++ b/src/HttpClient/ClientInterface.php
@@ -32,14 +32,14 @@ interface ClientInterface
      * @param string $method         request method
      * @param string $url            url
      * @param array  $defaultHeaders request headers
-     * @param array  $params         parameters
+     * @param array $params         parameters
      *
      * @return array
      * @throws ApiException
      */
-    public function sendRequest($method,
-        string $url,
-        array $defaultHeaders,
-        $params
-    );
+    public function sendRequest(string $method,
+                                string $url,
+                                array  $defaultHeaders,
+                                array $params
+    ): array;
 }

--- a/src/HttpClient/GuzzleClient.php
+++ b/src/HttpClient/GuzzleClient.php
@@ -58,7 +58,7 @@ class GuzzleClient implements ClientInterface
      *
      * @return GuzzleClient
      */
-    public static function instance()
+    public static function instance(): GuzzleClient
     {
         if (!self::$_instance) {
             self::$_instance = new self();
@@ -72,12 +72,12 @@ class GuzzleClient implements ClientInterface
      * @param string $method         request method
      * @param string $url            url
      * @param array  $defaultHeaders request headers
-     * @param array  $params         parameters
+     * @param array $params         parameters
      *
      * @return array
      * @throws ApiException
      */
-    public function sendRequest($method, string $url, array $defaultHeaders, $params)
+    public function sendRequest(string $method, string $url, array $defaultHeaders, array $params): array
     {
         $method = strtoupper($method);
 
@@ -88,14 +88,14 @@ class GuzzleClient implements ClientInterface
         $opts['params'] = $params;
 
         $response = $this->_executeRequest($opts, $url);
-        
+
         $rbody = $response[0];
         $rcode = $response[1];
         $rheader = $response[2];
 
         return [$rbody, $rcode, $rheader];
     }
-    
+
     /**
      * Execute request
      *
@@ -103,9 +103,9 @@ class GuzzleClient implements ClientInterface
      * @param string $url  request url
      *
      * @return array
-     * @throws ApiException
+     * @throws ApiException|\GuzzleHttp\Exception\GuzzleException
      */
-    private function _executeRequest(array $opts, string $url)
+    private function _executeRequest(array $opts, string $url): array
     {
         $headers = $opts['headers'];
         $params = $opts['params'];
@@ -114,9 +114,9 @@ class GuzzleClient implements ClientInterface
         try {
             if (count($params) > 0) {
                 $isQueryParam = isset($params['query-param']) && $params['query-param'] === 'true'; // additional condition to check if the requestor is imposing query param, otherwise default json
-                
+
                 if($isQueryParam) unset($params['query-param']);
-                
+
                 $response =  $this->http->request(
                     $opts['method'], $url, [
                         'auth' => [$apiKey, ''],
@@ -137,7 +137,7 @@ class GuzzleClient implements ClientInterface
             $rbody = json_decode($response->getBody()->getContents(), true);
             $rcode = $response->getStatusCode();
             $rheader = $response->getHeaders();
-    
+
             self::_handleAPIError(
                 array('body' => $rbody,
                       'code' => $rcode,
@@ -160,10 +160,10 @@ class GuzzleClient implements ClientInterface
      * @return void
      * @throws ApiException
      */
-    private static function _handleAPIError($response)
+    private static function _handleAPIError(array $response)
     {
         $rbody = $response['body'];
-        
+
         $rhttp = strval($response['code']);
         $message = $rbody['message'];
         $rcode = $rbody['error_code'];

--- a/src/HttpClientInterface.php
+++ b/src/HttpClientInterface.php
@@ -14,6 +14,10 @@
 namespace Xendit;
 
 
+use GuzzleHttp\Exception\GuzzleException;
+use Psr\Http\Message\ResponseInterface;
+use Psr\Http\Message\UriInterface;
+
 /**
  * Interface HttpClientInterface
  *
@@ -32,12 +36,12 @@ interface HttpClientInterface
      * relative path to append to the base path of the client. The URL can
      * contain the query string as well.
      *
-     * @param string              $method  HTTP method.
+     * @param string $method  HTTP method.
      * @param string|UriInterface $uri     URI object or string.
      * @param array               $options Request options to apply.
      *
      * @return ResponseInterface
      * @throws GuzzleException
      */
-    public function request($method, $uri, array $options = []);
+    public function request(string $method, $uri, array $options = []): ResponseInterface;
 }

--- a/src/Invoice.php
+++ b/src/Invoice.php
@@ -34,7 +34,7 @@ class Invoice
      *
      * @return string
      */
-    public static function classUrl()
+    public static function classUrl(): string
     {
         return "/v2/invoices";
     }
@@ -44,7 +44,7 @@ class Invoice
      *
      * @return array
      */
-    public static function createReqParams()
+    public static function createReqParams(): array
     {
         return ['external_id', 'amount'];
     }
@@ -74,9 +74,9 @@ class Invoice
      * ]
      * @throws Exceptions\ApiException
      */
-    public static function expireInvoice($id, $params=[])
+    public static function expireInvoice(string $id, array $params = []): array
     {
-        $url =  '/invoices/' . $id . '/expire!';
+        $url = '/invoices/' . $id . '/expire!';
 
         return static::_request('POST', $url, $params);
     }

--- a/src/PayLater.php
+++ b/src/PayLater.php
@@ -34,7 +34,7 @@ class PayLater
      *
      * @return string
      */
-    public static function classUrl()
+    public static function classUrl(): string
     {
         return "/paylater";
     }
@@ -47,7 +47,7 @@ class PayLater
      * @throws InvalidArgumentException
      * @throws ApiException
      */
-    public static function initiatePayLaterPlans($params = [])
+    public static function initiatePayLaterPlans(array $params = []): array
     {
         $requiredParams = [
             'customer_id',
@@ -72,7 +72,7 @@ class PayLater
      * @throws InvalidArgumentException
      * @throws ApiException
      */
-    public static function createPayLaterCharge($params = [])
+    public static function createPayLaterCharge(array $params = []): array
     {
         $requiredParams = [
             'plan_id',
@@ -87,7 +87,7 @@ class PayLater
 
         return static::_request('POST', $url, $params);
     }
-    
+
     /**
      * Get PayLater Charge by ID
      *
@@ -97,19 +97,19 @@ class PayLater
      * @throws InvalidArgumentException
      * @throws ApiException
      */
-    public static function getPayLaterChargeStatus($id, $params = [])
+    public static function getPayLaterChargeStatus(string $id, array $params = []): array
     {
         $requiredParams = [
-            
+
         ];
-        
+
         self::validateParams($params, $requiredParams);
-        
+
         $url = static::classUrl() . '/charges/'.$id;
-        
+
         return static::_request('GET', $url, $params);
     }
-    
+
     /**
      * Create Paylater Refund
      *
@@ -119,19 +119,19 @@ class PayLater
      * @throws InvalidArgumentException
      * @throws ApiException
      */
-    public static function createPayLaterRefund($id, $params = [])
+    public static function createPayLaterRefund(string $id, array $params = []): array
     {
         $requiredParams = [
-            
+
         ];
-        
+
         self::validateParams($params, $requiredParams);
-        
+
         $url = static::classUrl() . '/charges/'.$id.'/refunds';
-        
+
         return static::_request('POST', $url, $params);
     }
-    
+
     /**
      * Get Refund by Refund ID
      *
@@ -142,34 +142,35 @@ class PayLater
      * @throws InvalidArgumentException
      * @throws ApiException
      */
-    public static function getPayLaterRefund($charge_id, $refund_id, $params = [])
+    public static function getPayLaterRefund(string $charge_id, string $refund_id, array $params = []): array
     {
         $requiredParams = [
-            
+
         ];
-        
+
         self::validateParams($params, $requiredParams);
-        
+
         $url = static::classUrl() . '/charges/'.$charge_id.'/refunds/'.$refund_id;
-        
+
         return static::_request('GET', $url, $params);
     }
-    
+
     /**
      * List Paylater Refunds
      *
-     * @param array  $params Paylater Refunds params
+     * @param string $charge_id
+     * @param array $params Paylater Refunds params
      *
      * @return array
      * https://developers.xendit.co/api-reference/#list-paylater-refunds
      * @throws Exceptions\ApiException
      */
-    public static function listPayLaterRefund($charge_id, $params = [])
+    public static function listPayLaterRefund(string $charge_id, array $params = []): array
     {
         $url = static::classUrl() . '/charges/'.$charge_id.'/refunds/';
-        
+
         return static::_request('GET', $url, $params);
     }
-    
-    
+
+
 }

--- a/src/PaymentChannels.php
+++ b/src/PaymentChannels.php
@@ -34,7 +34,7 @@ class PaymentChannels
      * @throws Exceptions\ApiException
      * * GetPaymentChannels is in maintenance mode. Existing behavior on the endpoint will continue to work as before, but newer channels will be missing from the returned result.
      */
-    public static function list()
+    public static function list(): array
     {
         $url = '/payment_channels';
 

--- a/src/Payouts.php
+++ b/src/Payouts.php
@@ -33,7 +33,7 @@ class Payouts
      *
      * @return string
      */
-    public static function classUrl()
+    public static function classUrl(): string
     {
         return "/payouts";
     }
@@ -43,7 +43,7 @@ class Payouts
      *
      * @return array
      */
-    public static function createReqParams()
+    public static function createReqParams(): array
     {
         return ['external_id', 'amount', 'email'];
     }
@@ -67,7 +67,7 @@ class Payouts
      * ]
      * @throws Exceptions\ApiException
      */
-    public static function void($id)
+    public static function void(string $id): array
     {
         $url = static::classUrl() . '/' . $id . '/void';
 

--- a/src/PayoutsNew.php
+++ b/src/PayoutsNew.php
@@ -1,5 +1,15 @@
 <?php
 
+/**
+ * PayoutsNew.php
+ * php version 7.3.0
+ *
+ * @category Class
+ * @package  Xendit
+ * @author   Yanuar <yanuaraditia@outlook.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ * @link     https://api.xendit.co
+ */
 namespace Xendit;
 
 /**

--- a/src/PayoutsNew.php
+++ b/src/PayoutsNew.php
@@ -92,7 +92,7 @@ class PayoutsNew
      * ]
      * @throws \Xendit\Exceptions\ApiException
      */
-    public static function retrieveReference($referenceId, array $params = [])
+    public static function retrieveReference($referenceId, array $params = []): array
     {
         $url = static::classUrl() . '?reference_id=' . $referenceId;
         return static::_request('GET', $url, $params);
@@ -127,7 +127,7 @@ class PayoutsNew
      * ]
      * @throws Exceptions\ApiException
      */
-    public static function getPayoutsChannels()
+    public static function getPayoutsChannels(): array
     {
         $url = '/payouts_channels';
         return static::_request('GET', $url);
@@ -174,7 +174,7 @@ class PayoutsNew
      * ]
      * @throws \Xendit\Exceptions\ApiException
      */
-    public static function cancel(string $id)
+    public static function cancel(string $id): array
     {
         $url = static::classUrl() . '/' . $id . '/cancel';
         return static::_request('GET', $url);

--- a/src/Platform.php
+++ b/src/Platform.php
@@ -33,7 +33,7 @@ class Platform
      *
      * @return array
      */
-    public static function accountType()
+    public static function accountType(): array
     {
         return ["MANAGED", "OWNED"];
     }
@@ -43,7 +43,7 @@ class Platform
      *
      * @return array
      */
-    public static function unitRoute()
+    public static function unitRoute(): array
     {
         return ["percent", "flat"];
     }
@@ -51,11 +51,11 @@ class Platform
     /**
      * Validation for account type
      *
-     * @param string $account_type Account type
+     * @param string|null $account_type Account type
      *
      * @return void
      */
-    public static function validateAccountType($account_type = null)
+    public static function validateAccountType(string $account_type = null)
     {
         if (!in_array($account_type, self::accountType())) {
             $msg = "Account type is invalid. Available types: MANAGED, OWNED";
@@ -66,11 +66,11 @@ class Platform
     /**
      * Validation for unit route
      *
-     * @param string $unit unit route
+     * @param string|null $unit unit route
      *
      * @return void
      */
-    public static function validateUnitRoute($unit = null)
+    public static function validateUnitRoute(string $unit = null)
     {
         if (!in_array($unit, self::unitRoute())) {
             $msg = "Unit value is invalid. Available values: percent, flat";
@@ -81,13 +81,13 @@ class Platform
     /**
      * Create account
      *
-     * @param array  $params user params
+     * @param array $params user params
      *
      * @return array
      * https://developers.xendit.co/api-reference/#create-account
      * @throws Exceptions\ApiException
      */
-    public static function createAccount($params = [])
+    public static function createAccount(array $params = []): array
     {
         $requiredParams = ['email', 'type'];
 
@@ -108,9 +108,9 @@ class Platform
      * https://developers.xendit.co/api-reference/#get-account-by-id
      * @throws Exceptions\ApiException
      */
-    public static function getAccount($account_id)
+    public static function getAccount(string $account_id): array
     {
-        $url = '/v2/accounts/'.$account_id;
+        $url = '/v2/accounts/' . $account_id;
 
         return static::_request('GET', $url);
     }
@@ -118,20 +118,20 @@ class Platform
     /**
      * Update account
      *
-     * @param string  $account_id
-     * @param array  $params user params
+     * @param string $account_id
+     * @param array $params user params
      *
      * @return array
      * https://developers.xendit.co/api-reference/#update-account
      * @throws Exceptions\ApiException
      */
-    public static function updateAccount($account_id, $params = [])
+    public static function updateAccount(string $account_id, array $params = []): array
     {
         $requiredParams = ['email'];
 
         self::validateParams($params, $requiredParams);
 
-        $url = '/v2/accounts/'.$account_id;
+        $url = '/v2/accounts/' . $account_id;
 
         return static::_request('PATCH', $url, $params);
     }
@@ -139,13 +139,13 @@ class Platform
     /**
      * Create transfer
      *
-     * @param array  $params user params
+     * @param array $params user params
      *
      * @return array
      * https://developers.xendit.co/api-reference/#create-transfers
      * @throws Exceptions\ApiException
      */
-    public static function createTransfer($params = [])
+    public static function createTransfer(array $params = []): array
     {
         $requiredParams = ['reference', 'amount', 'source_user_id', 'destination_user_id'];
 
@@ -159,28 +159,28 @@ class Platform
     /**
      * Create fee rule
      *
-     * @param array  $params user params
+     * @param array $params user params
      *
      * @return array
      * https://developers.xendit.co/api-reference/#create-fee-rule
      * @throws Exceptions\ApiException
      */
-    public static function createFeeRule($params = [])
+    public static function createFeeRule(array $params = []): array
     {
         $requiredParams = ['name', 'unit', 'amount', 'currency'];
 
         self::validateParams($params, $requiredParams);
         self::validateUnitRoute($params['unit']);
 
-        $payload = array();
+        $payload         = array();
         $payload['name'] = $params['name'];
         if (isset($params['description'])) {
             $payload['description'] = $params['description'];
         }
         $payload['routes'] = [
             array(
-                'unit' => $params['unit'],
-                'amount' => $params['amount'],
+                'unit'     => $params['unit'],
+                'amount'   => $params['amount'],
                 'currency' => $params['currency']
             )
         ];
@@ -193,20 +193,20 @@ class Platform
     /**
      * Set Callback URL
      *
-     * @param string  $type
-     * @param array  $params user params
+     * @param string $type
+     * @param array $params user params
      *
      * @return array
      * https://developers.xendit.co/api-reference/#set-callback-urls
      * @throws Exceptions\ApiException
      */
-    public static function setCallbackUrl($type, $params = [])
+    public static function setCallbackUrl(string $type, array $params = []): array
     {
         $requiredParams = ['url'];
 
         self::validateParams($params, $requiredParams);
 
-        $url = '/callback_urls/'.$type;
+        $url = '/callback_urls/' . $type;
 
         return static::_request('POST', $url, $params);
     }

--- a/src/Promotion.php
+++ b/src/Promotion.php
@@ -32,7 +32,7 @@ class Promotion
      *
      * @return string
      */
-    public static function classUrl()
+    public static function classUrl(): string
     {
         return "/promotions";
     }
@@ -69,7 +69,7 @@ class Promotion
      *
      * @throws Exceptions\ApiException if request status code is not 2xx
      **/
-    public static function create($params = [])
+    public static function create(array $params = []): array
     {
         if (!array_key_exists('promo_code', $params)
             && !array_key_exists('bin_list', $params)

--- a/src/QRCode.php
+++ b/src/QRCode.php
@@ -36,7 +36,7 @@ class QRCode
      *
      * @return string
      */
-    public static function classUrl()
+    public static function classUrl(): string
     {
         return "/qr_codes";
     }
@@ -76,7 +76,7 @@ class QRCode
      * @throws InvalidArgumentException if some parameters are missing or invalid
      * @throws ApiException if request status code is not 2xx
      **/
-    public static function create($params = [])
+    public static function create(array $params = []): array
     {
         if (!array_key_exists('type', $params)) {
             $message = 'Please specify "type" inside your parameters.';
@@ -86,7 +86,7 @@ class QRCode
         $requiredParams = ['type'];
 
         if ($params['type'] === 'DYNAMIC') {
-            array_push($requiredParams, 'amount');
+            $requiredParams[] = 'amount';
         } elseif ($params['type'] !== 'STATIC') {
             $message = 'Invalid QR Code type';
             throw new InvalidArgumentException($message);
@@ -100,9 +100,11 @@ class QRCode
         }
 
         if ($params['api-version'] === QRCode::$apiVersion1) {
-            array_push($requiredParams, 'external_id', 'callback_url');
+            $requiredParams[] = 'external_id';
+            $requiredParams[] = 'callback_url';
         } elseif ($params['api-version'] === QRCode::$apiVersion2) {
-            array_push($requiredParams, 'reference_id', 'currency');
+            $requiredParams[] = 'reference_id';
+            $requiredParams[] = 'currency';
 
             if (array_key_exists('callback_url', $params)) {
                 $message = 'The API version 2022-07-31 does not support passing callback URL in the request. Please set the callback URL from your Xendit Dashboard instead.';
@@ -154,7 +156,7 @@ class QRCode
      *
      * @throws ApiException
      */
-    public static function get(string $id, string $api_version = null)
+    public static function get(string $id, string $api_version = null): array
     {
         $params = [];
         if ($api_version !== null) {

--- a/src/Recurring.php
+++ b/src/Recurring.php
@@ -34,7 +34,7 @@ class Recurring
      *
      * @return string
      */
-    public static function classUrl()
+    public static function classUrl(): string
     {
         return "/recurring_payments";
     }
@@ -44,7 +44,7 @@ class Recurring
      *
      * @return array
      */
-    public static function createReqParams()
+    public static function createReqParams(): array
     {
         return [
             'external_id',
@@ -61,7 +61,7 @@ class Recurring
      *
      * @return array
      */
-    public static function updateReqParams()
+    public static function updateReqParams(): array
     {
         return [];
     }
@@ -91,7 +91,7 @@ class Recurring
      * ]
      * @throws Exceptions\ApiException
      */
-    public static function stop($id)
+    public static function stop(string $id): array
     {
         $url = '/recurring_payments/' . $id . '/stop!';
 
@@ -123,7 +123,7 @@ class Recurring
      * ]
      * @throws Exceptions\ApiException
      */
-    public static function pause($id)
+    public static function pause(string $id): array
     {
         $url = '/recurring_payments/' . $id . '/pause!';
 
@@ -155,7 +155,7 @@ class Recurring
      * ]
      * @throws Exceptions\ApiException
      */
-    public static function resume($id)
+    public static function resume(string $id): array
     {
         $url = '/recurring_payments/' . $id . '/resume!';
 

--- a/src/Refund.php
+++ b/src/Refund.php
@@ -1,0 +1,59 @@
+<?php
+
+/**
+ * Refund.php
+ * php version 7.3.0
+ *
+ * @category Class
+ * @package  Xendit
+ * @author   Yanuar <yanuaraditia@outlook.co>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ * @link     https://api.xendit.co
+ */
+
+namespace Xendit;
+
+/**
+ * Class Refund
+ *
+ * @category Class
+ * @package  Xendit
+ * @author   Yanuar <yanuaraditia@outlook.co>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ * @link     https://api.xendit.co
+ */
+class Refund
+{
+    use ApiOperations\Request;
+    use ApiOperations\Create;
+    use ApiOperations\Retrieve;
+    use ApiOperations\RetrieveAll;
+
+    /**
+     * Instantiate base URL
+     *
+     * @return string
+     */
+    public static function classUrl(): string
+    {
+        return "/refunds";
+    }
+
+    /**
+     * Instantiate required params for Create
+     *
+     * @return string[]
+     */
+    public static function createReqParams(): array
+    {
+        return [
+            'payment_request_id',
+            'reference_id',
+            'invoice_id',
+            'currency',
+            'amount',
+            'reason',
+            'metadata'
+        ];
+    }
+}

--- a/src/Report.php
+++ b/src/Report.php
@@ -34,7 +34,7 @@ class Report
      *
      * @return array
      */
-    public static function reportType()
+    public static function reportType(): array
     {
         return ["BALANCE_HISTORY", "TRANSACTIONS", "UPCOMING_TRANSACTIONS"];
     }
@@ -42,11 +42,11 @@ class Report
     /**
      * Validation for report type
      *
-     * @param string $report_type Report type
+     * @param string|null $report_type Report type
      *
      * @return void
      */
-    public static function validateReportType($report_type = null)
+    public static function validateReportType(string $report_type = null)
     {
         if (!in_array($report_type, self::reportType())) {
             $msg = "Report type is invalid. Available types: MANAGED, OWNED";
@@ -57,13 +57,13 @@ class Report
     /**
      * Generate report
      *
-     * @param array  $params reports params
+     * @param array $params reports params
      *
      * @return array
      * https://developers.xendit.co/api-reference/#generate-report
      * @throws Exceptions\ApiException
      */
-    public static function generate($params = [])
+    public static function generate(array $params = []): array
     {
         $requiredParams = ['type'];
 
@@ -84,7 +84,7 @@ class Report
      * https://developers.xendit.co/api-reference/#get-report
      * @throws Exceptions\ApiException
      */
-    public static function detail(string $report_id)
+    public static function detail(string $report_id): array
     {
         $url = '/reports/'.$report_id;
 

--- a/src/Retail.php
+++ b/src/Retail.php
@@ -34,7 +34,7 @@ class Retail
      *
      * @return string
      */
-    public static function classUrl()
+    public static function classUrl(): string
     {
         return "/fixed_payment_code";
     }
@@ -44,7 +44,7 @@ class Retail
      *
      * @return array
      */
-    public static function createReqParams()
+    public static function createReqParams(): array
     {
         return ['external_id', 'retail_outlet_name', 'name', 'expected_amount'];
     }
@@ -54,7 +54,7 @@ class Retail
      *
      * @return array
      */
-    public static function updateReqParams()
+    public static function updateReqParams(): array
     {
         return [];
     }

--- a/src/Transaction.php
+++ b/src/Transaction.php
@@ -29,13 +29,13 @@ class Transaction
     /**
      * List transactions
      *
-     * @param array  $params transaction params
+     * @param array $params transaction params
      *
      * @return array
      * https://developers.xendit.co/api-reference/#get-transaction
      * @throws Exceptions\ApiException
      */
-    public static function list($params = [])
+    public static function list(array $params = []): array
     {
         $url = '/transactions';
 
@@ -51,7 +51,7 @@ class Transaction
      * https://developers.xendit.co/api-reference/#get-transaction
      * @throws Exceptions\ApiException
      */
-    public static function detail(string $transaction_id)
+    public static function detail(string $transaction_id): array
     {
         $url = '/transactions/'.$transaction_id;
 

--- a/src/VirtualAccounts.php
+++ b/src/VirtualAccounts.php
@@ -34,7 +34,7 @@ class VirtualAccounts
      *
      * @return string
      */
-    public static function classUrl()
+    public static function classUrl(): string
     {
         return "/callback_virtual_accounts";
     }
@@ -44,7 +44,7 @@ class VirtualAccounts
      *
      * @return array
      */
-    public static function createReqParams()
+    public static function createReqParams(): array
     {
         return ['external_id', 'bank_code', 'name'];
     }
@@ -54,7 +54,7 @@ class VirtualAccounts
      *
      * @return array
      */
-    public static function updateReqParams()
+    public static function updateReqParams(): array
     {
         return [];
     }
@@ -68,7 +68,7 @@ class VirtualAccounts
      * ]
      * @throws Exceptions\ApiException
      */
-    public static function getVABanks()
+    public static function getVABanks(): array
     {
         $url = '/available_virtual_account_banks';
 
@@ -93,7 +93,7 @@ class VirtualAccounts
      * ]
      * @throws Exceptions\ApiException
      */
-    public static function getFVAPayment($payment_id)
+    public static function getFVAPayment(string $payment_id): array
     {
         $url = '/callback_virtual_account_payments/payment_id=' . $payment_id;
 

--- a/src/Xendit.php
+++ b/src/Xendit.php
@@ -14,6 +14,7 @@
 namespace Xendit;
 
 use Dotenv\Dotenv;
+use Xendit\HttpClient\GuzzleClient;
 
 /**
  * Class Xendit
@@ -35,6 +36,9 @@ class Xendit
     private static $_httpClient;
 
     const VERSION = "2.18.0";
+
+    public function __construct() {
+    }
 
     /**
      * ApiBase getter
@@ -112,7 +116,7 @@ class Xendit
      *
      * @return void
      */
-    public static function setHttpClient(HttpClientInterface $client): void
+    public static function setHttpClient($client): void
     {
         self::$_httpClient = $client;
     }
@@ -122,7 +126,7 @@ class Xendit
      *
      * @return HttpClientInterface
      */
-    public static function getHttpClient(): HttpClientInterface
+    public static function getHttpClient()
     {
         return self::$_httpClient;
     }

--- a/src/Xendit.php
+++ b/src/Xendit.php
@@ -63,7 +63,7 @@ class Xendit
      *
      * @return string Secret API key
      */
-    public static function getApiKey()
+    public static function getApiKey(): string
     {
         return self::$apiKey;
     }
@@ -75,7 +75,7 @@ class Xendit
      *
      * @return void
      */
-    public static function setApiKey($apiKey)
+    public static function setApiKey(string $apiKey)
     {
         self::$apiKey = $apiKey;
     }
@@ -96,11 +96,11 @@ class Xendit
     /**
      * Set library version
      *
-     * @param string $libVersion library version
+     * @param string|null $libVersion library version
      *
      * @return void
      */
-    public static function setLibVersion($libVersion = null): void
+    public static function setLibVersion(string $libVersion = null): void
     {
         self::$libVersion = $libVersion;
     }
@@ -122,7 +122,7 @@ class Xendit
      *
      * @return HttpClientInterface
      */
-    public static function getHttpClient()
+    public static function getHttpClient(): HttpClientInterface
     {
         return self::$_httpClient;
     }

--- a/tests/TestCase.php
+++ b/tests/TestCase.php
@@ -97,20 +97,20 @@ class TestCase extends \PHPUnit\Framework\TestCase
      *
      * @param string $method   HTTP method
      * @param string $path     relative url
-     * @param array  $params   user params
-     * @param array  $headers  request headers
-     * @param array  $response response
-     * @param int    $rcode    response code
+     * @param array $params   user params
+     * @param array $headers  request headers
+     * @param array $response response
+     * @param int $rcode    response code
      *
      * @return void
      */
     protected function stubRequest(
-        $method,
-        $path,
-        $params = [],
-        $headers = [],
-        $response = [],
-        $rcode = 200
+        string $method,
+        string $path,
+        array  $params = [],
+        array  $headers = [],
+        array  $response = [],
+        int $rcode = 200
     ) {
         $this->_prepareRequestMock($method, $path, $params, $headers)
             ->willReturn([json_encode($response), $rcode, []]);

--- a/tests/Xendit/DisbursementsChannelsTest.php
+++ b/tests/Xendit/DisbursementsChannelsTest.php
@@ -152,11 +152,11 @@ class DisbursementsChannelsTest extends TestCase
      * Should throw ApiException
      *
      * @return void
-     * @throws \Xendit\Exceptions\ApiException
+     * @throws \Xendit\Exceptions\ApiException | \TypeError
      */
     public function testIsGettableDisbursementChannelsByChannelCategoryThrowApiException()
     {
-        $this->expectException(\Xendit\Exceptions\ApiException::class);
+        $this->expectException(TypeError::class);
         DisbursementChannels::getDisbursementChannelsByChannelCategory(null);
     }
 
@@ -207,11 +207,11 @@ class DisbursementsChannelsTest extends TestCase
      * Should throw ApiException
      *
      * @return void
-     * @throws \Xendit\Exceptions\ApiException
+     * @throws \Xendit\Exceptions\ApiException | \TypeError
      */
     public function testIsGettableDisbursementChannelsByChannelCodeThrowApiException()
     {
-        $this->expectException(\Xendit\Exceptions\ApiException::class);
+        $this->expectException(TypeError::class);
         DisbursementChannels::getDisbursementChannelsByChannelCode(null);
     }
 }

--- a/tests/Xendit/DisbursementsPHPTest.php
+++ b/tests/Xendit/DisbursementsPHPTest.php
@@ -206,7 +206,7 @@ class DisbursementsPHPTest extends TestCase
      * 'updated'=> 'Date',
      * receipt_notification => Array
      * beneficiary => Array]
-     * @throws Exceptions\ApiException
+     * @throws \Xendit\Exceptions\ApiException
      */
     public function testIsGettablePHPDisbursementsByReferenceID()
     {
@@ -253,7 +253,7 @@ class DisbursementsPHPTest extends TestCase
      */
     public function testIsGettablePHPDisbursementsByReferenceIDThrowApiException()
     {
-        $this->expectException(\Xendit\Exceptions\ApiException::class);
+        $this->expectException(TypeError::class);
 
         $result = DisbursementsPHP::getPHPDisbursementsByReferenceID(null);
         var_dump($result);

--- a/tests/Xendit/PlatformTest.php
+++ b/tests/Xendit/PlatformTest.php
@@ -29,6 +29,8 @@ class PlatformTest extends TestCase
 {
     const ACCOUNT_TYPE = 'OWNED';
     const ACCOUNT_EMAIL = 'customer@website.com';
+
+    const ACCOUNT_ID = "5cafeb170a2b18519b1b8761";
     const ACCOUNT_BUSINESS_NAME = 'customer company';
 
     /**
@@ -41,8 +43,8 @@ class PlatformTest extends TestCase
     public function testAccountIsCreatable()
     {
         $expected = [
-            'email' => self::ACCOUNT_EMAIL,
-            'type' => self::ACCOUNT_TYPE,
+            'email'          => self::ACCOUNT_EMAIL,
+            'type'           => self::ACCOUNT_TYPE,
             'public_profile' => ['business_name' => self::ACCOUNT_BUSINESS_NAME]
         ];
 
@@ -70,12 +72,12 @@ class PlatformTest extends TestCase
     public function testAccountIsGettable()
     {
         $expectedResponse = [
-            'id' => '5cafeb170a2b18519b1b8761',
+            'id'      => '5cafeb170a2b18519b1b8761',
             'created' => '2021-01-01T10:00:00Z',
             'updated' => '2021-01-01T10:00:00Z',
-            'type'=> 'OWNED',
-            'email'=> 'angie@pinkpanther.com',
-            'status'=> 'LIVE',
+            'type'    => 'OWNED',
+            'email'   => 'angie@pinkpanther.com',
+            'status'  => 'LIVE',
         ];
         $this->stubRequest(
             'GET',
@@ -85,7 +87,7 @@ class PlatformTest extends TestCase
             $expectedResponse
         );
 
-        $result = Platform::getAccount('5cafeb170a2b18519b1b8761');
+        $result = Platform::getAccount(self::ACCOUNT_ID);
         $this->assertEquals($result['id'], $expectedResponse['id']);
         $this->assertEquals($result['type'], $expectedResponse['type']);
     }
@@ -100,8 +102,8 @@ class PlatformTest extends TestCase
     public function testAccountIsUpdatable()
     {
         $expected = [
-            'email' => self::ACCOUNT_EMAIL,
-            'public_profile' => ['business_name' => self::ACCOUNT_BUSINESS_NAME.' Updated']
+            'email'          => self::ACCOUNT_EMAIL,
+            'public_profile' => ['business_name' => self::ACCOUNT_BUSINESS_NAME . ' Updated']
         ];
 
         $this->stubRequest(
@@ -127,9 +129,9 @@ class PlatformTest extends TestCase
     public function testTransferIsCreatable()
     {
         $expected = [
-            'reference' => ''.time(),
-            'amount' => 50000,
-            'source_user_id' => '54afeb170a2b18519b1b8768',
+            'reference'           => '' . time(),
+            'amount'              => 50000,
+            'source_user_id'      => '54afeb170a2b18519b1b8768',
             'destination_user_id' => '5cafeb170a2b1851246b8768',
         ];
 
@@ -157,20 +159,20 @@ class PlatformTest extends TestCase
     public function testFeeRuleIsCreatable()
     {
         $params = [
-            'name' => 'standard_platform_fee',
+            'name'        => 'standard_platform_fee',
             'description' => 'Fee charged to insurance agents based in Java',
-            'unit' => 'flat',
-            'amount' => 6500,
-            'currency' => 'IDR'
+            'unit'        => 'flat',
+            'amount'      => 6500,
+            'currency'    => 'IDR'
         ];
 
         $expected = [
-            'name' => 'standard_platform_fee',
+            'name'        => 'standard_platform_fee',
             'description' => 'Fee charged to insurance agents based in Java',
-            'routes' => [
+            'routes'      => [
                 array(
-                    'unit' => 'flat',
-                    'amount' => 6500,
+                    'unit'     => 'flat',
+                    'amount'   => 6500,
                     'currency' => 'IDR'
                 )
             ]
@@ -198,14 +200,14 @@ class PlatformTest extends TestCase
      */
     public function testCallbackUrlIsCreatable()
     {
-        $expected = [
+        $expected     = [
             'url' => 'https://webhook.site/c9c9140b-96b8-434c-9c59-7440eeae4d7f'
         ];
         $callbackType = 'invoice';
 
         $this->stubRequest(
             'POST',
-            '/callback_urls/'.$callbackType,
+            '/callback_urls/' . $callbackType,
             $expected,
             [],
             $expected
@@ -254,11 +256,11 @@ class PlatformTest extends TestCase
     public function testAccountIsUpdatetableThrowsException()
     {
         $expected = [
-            'public_profile' => ['business_name' => self::ACCOUNT_BUSINESS_NAME.' Updated']
+            'public_profile' => ['business_name' => self::ACCOUNT_BUSINESS_NAME . ' Updated']
         ];
 
         $this->expectException(\Xendit\Exceptions\InvalidArgumentException::class);
-        Platform::updateAccount($expected);
+        Platform::updateAccount(self::ACCOUNT_ID, $expected);
     }
 
     /**
@@ -301,7 +303,7 @@ class PlatformTest extends TestCase
      */
     public function testCallbackurlIsCreatableThrowsException()
     {
-        $expected = [];
+        $expected     = [];
         $callbackType = 'invoice';
 
         $this->expectException(\Xendit\Exceptions\InvalidArgumentException::class);

--- a/tests/Xendit/RefundTest.php
+++ b/tests/Xendit/RefundTest.php
@@ -1,0 +1,129 @@
+<?php
+
+namespace Xendit;
+
+/**
+ * Class InvoiceTest
+ *
+ * @category Class
+ * @package  Xendit
+ * @author   Yanuar <yanuaraditia@outlook.com>
+ * @license  https://opensource.org/licenses/MIT MIT License
+ * @link     https://api.xendit.co
+ */
+class RefundTest extends TestCase
+{
+    const TEST_RESOURCE_ID = 'xx-232323';
+
+
+    /**
+     * Create Refund test
+     * Should pass
+     *
+     * @return void
+     */
+    public function testIsCreatable()
+    {
+        $params = [
+            'payment_request_id' => 'samp-2232323',
+            'reference_id'       => 'ref-23232m23n',
+            'invoice_id'         => 'inv-232323232',
+            'currency'           => "IDR",
+            'amount'             => 30000,
+            'reason'             => 'Cancel Payment',
+            'metadata'           => null
+        ];
+
+        $this->stubRequest(
+            'POST',
+            '/refunds',
+            $params,
+            [],
+            $params
+        );
+
+        $resource = Refund::create($params);
+        $this->assertEquals($resource['payment_request_id'], $params['payment_request_id']);
+        $this->assertEquals($resource['reference_id'], $params['reference_id']);
+        $this->assertEquals($resource['invoice_id'], $params['invoice_id']);
+        $this->assertEquals($resource['amount'], $params['amount']);
+    }
+
+    /**
+     * Get Refund test
+     * Should pass
+     *
+     * @return void
+     */
+    public function testIsGettable()
+    {
+        $this->stubRequest(
+            'get',
+            '/refunds/' . self::TEST_RESOURCE_ID,
+            [],
+            [],
+            [
+                'id' => self::TEST_RESOURCE_ID
+            ]
+        );
+
+        $resource = Refund::retrieve(self::TEST_RESOURCE_ID);
+        $this->assertEquals($resource['id'], self::TEST_RESOURCE_ID);
+    }
+
+
+    /**
+     * GetAll Refund test
+     * Should pass
+     *
+     * @return void
+     */
+    public function testIsListable()
+    {
+        $this->stubRequest(
+            'GET',
+            '/v2/invoices',
+            [],
+            [],
+            [
+                'data' => [
+                    'id' => self::TEST_RESOURCE_ID
+                ]
+            ]
+        );
+
+        $resources = Refund::retrieveAll();
+        $this->assertTrue(is_array($resources['data']));
+        $this->assertTrue(array_key_exists('id', $resources['data']));
+    }
+
+    /**
+     * Create Refund test
+     * Should throw InvalidArgumentException
+     *
+     * @return void
+     */
+    public function testIsCreatableThrowInvalidArgumentException()
+    {
+        $this->expectException(\Xendit\Exceptions\InvalidArgumentException::class);
+        $params = [
+            'amount' => 10000
+        ]; // We remove reason field which required
+
+        Refund::create($params);
+    }
+
+    /**
+     * Get Refund test
+     * Should throw ApiException
+     *
+     * @return void
+     */
+    public function testIsGettableThrowApiException()
+    {
+        $this->expectException(\Xendit\Exceptions\ApiException::class);
+
+        Refund::retrieve(self::TEST_RESOURCE_ID);
+    }
+
+}

--- a/tests/Xendit/RefundTest.php
+++ b/tests/Xendit/RefundTest.php
@@ -3,7 +3,7 @@
 namespace Xendit;
 
 /**
- * Class InvoiceTest
+ * Class RefundTest
  *
  * @category Class
  * @package  Xendit
@@ -82,7 +82,7 @@ class RefundTest extends TestCase
     {
         $this->stubRequest(
             'GET',
-            '/v2/invoices',
+            '/refunds',
             [],
             [],
             [


### PR DESCRIPTION
## Changelog
- [x] Implement the refunds method on [https://developers.xendit.co/api-reference/#refunds](https://developers.xendit.co/api-reference/#refunds)
- [x] Update typed declarations for much strict data passed into method params, ref [https://www.php.net/manual/en/language.types.declarations.php](https://www.php.net/manual/en/language.types.declarations.php)
- [x] Update old method and replace ``array_push($args,'value');`` with ``$args[] = 'value';``
- [x] Update `DisbursementPHPTest`, `DisbursementChannelsTest` error catching from `\Xendit\Exceptions\ApiException` into `TypeError` exception. This changes to accomodate typed declarations provided by php itself
- [x] Avoid deprecations notice by upgrade `actions/cache` from `2` into `3.2.6`. Ref [https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/](https://github.blog/changelog/2022-10-11-github-actions-deprecating-save-state-and-set-output-commands/) 

cc @xen-HendryZheng 