### PR TITLE
Enabling developer to set custom 'callback-url' to any Requests sent to Xendit API.

### DIFF
--- a/src/ApiOperations/Request.php
+++ b/src/ApiOperations/Request.php
@@ -94,6 +94,10 @@ trait Request
             $headers['X-API-VERSION'] = $params['X-API-VERSION'];
         }
 
+        if (array_key_exists('callback-url'), $params) {
+            $headers['callback-url'] = $params ['callback-url']
+        }
+
         $requestor = new \Xendit\ApiRequestor();
         return $requestor->request($method, $url, $params, $headers);
     }

--- a/src/ApiOperations/Request.php
+++ b/src/ApiOperations/Request.php
@@ -74,7 +74,7 @@ trait Request
         }
 
         if (array_key_exists('callback-url', $params)) {
-            $headers['callback-url'] = $params ['callback-url'];
+            $headers['callback-url'] = $params['callback-url'];
             unset($params['callback-url']);
         }
 

--- a/src/ApiOperations/Request.php
+++ b/src/ApiOperations/Request.php
@@ -73,6 +73,11 @@ trait Request
             $headers['with-fee-rule'] = $params['with-fee-rule'];
         }
 
+        if (array_key_exists('callback-url'), $params) {
+            $headers['callback-url'] = $params ['callback-url'];
+            unset($params['callback-url']);
+        }
+
         if (array_key_exists('Idempotency-key', $params)) {
             $headers['Idempotency-key'] = $params['Idempotency-key'];
         }
@@ -92,10 +97,6 @@ trait Request
 
         if (array_key_exists('X-API-VERSION', $params)) {
             $headers['X-API-VERSION'] = $params['X-API-VERSION'];
-        }
-
-        if (array_key_exists('callback-url'), $params) {
-            $headers['callback-url'] = $params ['callback-url']
         }
 
         $requestor = new \Xendit\ApiRequestor();

--- a/src/ApiOperations/Request.php
+++ b/src/ApiOperations/Request.php
@@ -73,7 +73,7 @@ trait Request
             $headers['with-fee-rule'] = $params['with-fee-rule'];
         }
 
-        if (array_key_exists('callback-url'), $params) {
+        if (array_key_exists('callback-url', $params)) {
             $headers['callback-url'] = $params ['callback-url'];
             unset($params['callback-url']);
         }


### PR DESCRIPTION
According to https://docs.xendit.co/ewallet/integrations/best-practices, it is possible to set up a dynamic callback URL by including 'callback-url' in the request header, but I couldn't find any ways to include this in the current xendit-php.

This is my fix for it. Coders now only need to add 'callback-url' to the parameter used in src/ApiOperations/Request.php.
![image](https://github.com/xendit/xendit-php/assets/17472074/27b8fdff-ed81-4ad4-ac94-3c0617f171ea)